### PR TITLE
Add missing styles to result files to render colors correctly

### DIFF
--- a/_conferences/atc2022/results.md
+++ b/_conferences/atc2022/results.md
@@ -3,6 +3,57 @@ title: Results
 order: 40
 ---
 
+
+<style>
+table th:first-of-type {
+    width: 60%;
+    margin-top:10px;
+    margin-bottom:10px;
+}
+table th:nth-of-type(2) {
+    width: 20%;
+    margin-top:10px;
+    margin-bottom:10px;
+}
+table th:nth-of-type(3) {
+    width: 20%;
+    margin-top:10px;
+    margin-bottom:10px;
+}
+
+table td {
+    padding:0.25em;
+}
+
+span#aa {
+    background-color:#f15c24;
+    color:#FFFFFF;
+    font-weight: bold;
+    display: inline-block;
+    margin: 0px 0px 0px 0px;
+    width:100%;
+}
+
+span#af {
+    background-color:#1274bb;
+    color:#FFFFFF;
+    font-weight: bold;
+    display: inline-block;
+    margin: 0px 0px 0px 0px;
+    width:100%;
+}
+
+span#rr {
+    background-color:#6c4099;
+    color:#FFFFFF;
+    font-weight: bold;
+    display: inline-block;
+    margin: 0px 0px 0px 0px;
+    width:100%;
+}
+
+</style>
+
 **Submissions**: 52 (81% of accepted papers)
 
 **Evaluation Results**:
@@ -48,7 +99,7 @@ order: 40
 | [Towards Latency Awareness for Content Delivery Network Caching]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/GYan58/la-cache-atc22) |
 | [HyperEnclave: An Open and Cross-platform Trusted Execution Environment]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/HyperEnclave/atc22-ae) |
 | [Privbox: Faster System Calls Through Sandboxed Privileged Execution]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/privbox/devenv) |
-| [Help Rather Than Recycle: Alleviating Cold Startup in Serverless Computing Through Inter-Function Container Sharing]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/lzjzx1122/Pagurus) |     
+| [Help Rather Than Recycle: Alleviating Cold Startup in Serverless Computing Through Inter-Function Container Sharing]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/lzjzx1122/Pagurus) |
 | [SoftTRR: Protect Page Tables against Rowhammer Attacks using Software-only Target Row Refresh]() | <span id="aa">AVAILABLE</span> | [figshare](https://doi.org/10.6084/m9.figshare.19721692) |
 | [Speculative Recovery: Cheap, Highly Available Fault Tolerance with Disaggregated Storage]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/princeton-sns/specreds) |
 | [CoVA: Exploiting Compressed-Domain Analysis to Accelerate Video Analytics]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/casys-kaist/CoVA) |

--- a/_conferences/osdi2021/results.md
+++ b/_conferences/osdi2021/results.md
@@ -3,6 +3,56 @@ title: Results
 order: 40
 ---
 
+<style>
+table th:first-of-type {
+    width: 60%;
+    margin-top:10px;
+    margin-bottom:10px;
+}
+table th:nth-of-type(2) {
+    width: 20%;
+    margin-top:10px;
+    margin-bottom:10px;
+}
+table th:nth-of-type(3) {
+    width: 20%;
+    margin-top:10px;
+    margin-bottom:10px;
+}
+
+table td {
+    padding:0.25em;
+}
+
+span#aa {
+    background-color:#f15c24;
+    color:#FFFFFF;
+    font-weight: bold;
+    display: inline-block;
+    margin: 0px 0px 0px 0px;
+    width:100%;
+}
+
+span#af {
+    background-color:#1274bb;
+    color:#FFFFFF;
+    font-weight: bold;
+    display: inline-block;
+    margin: 0px 0px 0px 0px;
+    width:100%;
+}
+
+span#rr {
+    background-color:#6c4099;
+    color:#FFFFFF;
+    font-weight: bold;
+    display: inline-block;
+    margin: 0px 0px 0px 0px;
+    width:100%;
+}
+
+</style>
+
 **Submissions**: 26 (84% of accepted papers)
 
 **Evaluation Results**:

--- a/_conferences/osdi2022/results.md
+++ b/_conferences/osdi2022/results.md
@@ -3,6 +3,57 @@ title: Results
 order: 40
 ---
 
+
+<style>
+table th:first-of-type {
+    width: 60%;
+    margin-top:10px;
+    margin-bottom:10px;
+}
+table th:nth-of-type(2) {
+    width: 20%;
+    margin-top:10px;
+    margin-bottom:10px;
+}
+table th:nth-of-type(3) {
+    width: 20%;
+    margin-top:10px;
+    margin-bottom:10px;
+}
+
+table td {
+    padding:0.25em;
+}
+
+span#aa {
+    background-color:#f15c24;
+    color:#FFFFFF;
+    font-weight: bold;
+    display: inline-block;
+    margin: 0px 0px 0px 0px;
+    width:100%;
+}
+
+span#af {
+    background-color:#1274bb;
+    color:#FFFFFF;
+    font-weight: bold;
+    display: inline-block;
+    margin: 0px 0px 0px 0px;
+    width:100%;
+}
+
+span#rr {
+    background-color:#6c4099;
+    color:#FFFFFF;
+    font-weight: bold;
+    display: inline-block;
+    margin: 0px 0px 0px 0px;
+    width:100%;
+}
+
+</style>
+
 **Submissions**: 35 (71% of accepted papers)
 
 **Evaluation Results**:
@@ -20,8 +71,8 @@ order: 40
 | [Achieving μs-scale Preemption for Concurrent GPU-accelerated DNN Inferences]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/SJTU-IPADS/reef-artifacts) |
 | [BlackBox: Secure Containers on Untrusted Operating Systems using Arm Virtualization Hardware]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br> | [Github](https://github.com/columbia/osdi22-paper162-ae) |
 | [Trinity: Desirable Mobile Emulation through Graphics Projection]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/TrinityEmulator/TrinityEmulator) |
-| [TriCache: A User-Transparent Block Cache Enabling High-Performance Out-of-Core Processing with In-Memory Programs]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/thu-pacman/TriCache) |     
-| [FAERY: An FPGA-accelerated Embedding-based Retrieval System]() |<span id="af">FUNCTIONAL</span> | |     
+| [TriCache: A User-Transparent Block Cache Enabling High-Performance Out-of-Core Processing with In-Memory Programs]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/thu-pacman/TriCache) |
+| [FAERY: An FPGA-accelerated Embedding-based Retrieval System]() |<span id="af">FUNCTIONAL</span> | |
 | [Coffers: Capability-Based Isolation and Sharing for Microservices]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><span id="rr">REPRODUCED</span> | [Github](https://github.com/lsds/intravisor) |
 | [zIO: Accelerating IO-Intensive Applications with Transparent Zero-Copy IO]() | <span id="aa">AVAILABLE</span> | [Github](https://github.com/tstamler/zIO) |
 | [UPGRADVISOR: Early Adopting Dependency Updates Using Production Traces]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://figshare.com/s/69057b2bf22e0aa8a645) |


### PR DESCRIPTION
Current:
![image](https://user-images.githubusercontent.com/15247084/188995417-aa5f8e45-ce54-4f97-bc65-7631161b42b5.png)

Correct:
![image](https://user-images.githubusercontent.com/15247084/188995380-64d00b07-5d0c-46d1-84b7-c01130e2761f.png)

Misses style definitions in the results page. I'm not sure how to amend the general css file to include the span definitions for all pages. @SolalPirelli any thoughts?