### PR TITLE
Yamlfying OSDI 20-24 and ATC 21-24, and simplifying SOSP 21/23 and SC21

### DIFF
--- a/_conferences/atc2022/results.md
+++ b/_conferences/atc2022/results.md
@@ -1,58 +1,167 @@
 ---
 title: Results
 order: 40
+available_img: "usenix_available.svg"
+available_name: "Artifacts Available"
+functional_img: "usenix_functional.svg"
+functional_name: "Artifacts Evaluated - Functional"
+reproduced_img: "usenix_reproduced.svg"
+reproduced_name: "Results Reproduced"
+
+artifacts:
+  - title: "Zero-Change Object Transmission for Distributed Big Data Analytics"
+    badges: "Functional,Reproduced"
+  - title: "Addrminer: A Comprehensive Global Active IPv6 Address Discovery System"
+    badges: "Available"
+    repository_url: "https://github.com/AddrMiner/AddrMiner"
+  - title: "Meces: Latency-efficient Rescaling via Prioritized State Migration for Stateful Distributed Stream Processing Systems"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/ATC2022No63/Meces-Artifact"
+  - title: "BBQ: A Block-based Bounded Queue for Exchanging Data and Profiling"
+    badges: "Functional,Reproduced"
+  - title: "Riker: Always-Correct and Fast Incremental Builds from Simple Specifications"
+    badges: "Available,Functional,Reproduced"
+    artifact_url: "https://doi.org/10.5281/zenodo.6544966"
+  - title: "Secure and Lightweight Deduplicated Storage via Shielded Deduplication-Before-Encryption"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/yzr95924/DEBE"
+  - title: "CBMM: Financial Advice for Kernel Memory Managers"
+    badges: "Available,Functional"
+    repository_url: "https://github.com/multifacet/cbmm-artifact"
+  - title: "IPLFS: Log-Structured File System without Garbage Collection"
+    badges: "Available"
+    repository_url: "https://github.com/ESOS-Lab/IPLFS"
+  - title: "EPK: Scalable and Efficient Memory Protection Key"
+    badges: "Functional,Reproduced"
+    repository_url: "https://github.com/SJTU-IPADS/EPK"
+  - title: "StRAID: Stripe-threaded Architecture for Parity-based RAIDs with Ultra-fast SSDs"
+    badges: "Available"
+    repository_url: "https://github.com/wsczq1/straid"
+  - title: "Not that Simple: Email Delivery in the 21st Century"
+    badges: "Available"
+    repository_url: "https://github.com/ichdasich/email-measurement-toolchain"
+  - title: "Pacman: An Efficient Compaction Approach for Log-Structured Key-Value Store on Persistent Memory"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/thustorage/pacman"
+  - title: "Serving Heterogeneous Machine Learning Models on Multi-GPU Servers with Spatio-Temporal Sharing"
+    badges: "Available"
+    repository_url: "https://doi.org/10.5281/zenodo.6544909"
+  - title: "Investigating Managed Language Runtime Performance: Why JavaScript and Python are 8x and 29x slower than C++, yet Java and Go can be Faster?"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/dsrg-uoft/LangBench"
+  - title: "Sift: Using Refinement-guided Automation to Verify Complex Distributed Systems"
+    badges: "Available,Functional"
+    repository_url: "https://github.com/GLaDOS-Michigan/Sift"
+  - title: "KRCORE: a microsecond-scale RDMA control plane for elastic computing"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/SJTU-IPADS/krcore-artifacts.git"
+  - title: "Faith: An Efficient Framework for Transformer Verification on GPUs"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/BoyuanFeng/Faith"
+  - title: "NVMe SSD Failures in the Field: the Fail-Stop and the Fail-Slow"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/Excelsiorrr/AE"
+  - title: "FlatFS: Flatten Hierarchical File System Namespace on Non-volatile Memories"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/miaogecm/FlatFS.git"
+  - title: "PetS: A Unified Framework for Parameter-Efficient Transformers Serving"
+    badges: "Available,Functional"
+    artifact_url: "https://zenodo.org/record/6534753#.YnpJtoxBz31"
+  - title: "RunD: A Lightweight Secure Container Runtime for High-density Deployment and High-concurrency Startup in Serverless Computing"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/chengjiagan/RunD_ATC22"
+  - title: "Building a High-performance Fine-grained Deduplication Framework for Backup Storage with High Deduplication Ratio"
+    badges: "Available,Functional"
+    repository_url: "https://github.com/Borelset/MeGA"
+  - title: "Automatic Recovery of Fine-grained Compiler Artifacts at the Binary Level"
+    badges: "Functional,Reproduced"
+  - title: "FpgaNIC: An FPGA-based Versatile 100Gb SmartNIC for GPUs"
+    badges: "Available,Functional<br>"
+    repository_url: "https://github.com/carlzhang4/FPGANic"
+  - title: "Whale: Efficient Giant Model Training over Heterogeneous GPUs"
+    badges: "Available,Functional"
+    repository_url: "https://github.com/alibaba/EasyParallelLibrary"
+  - title: "Critical Path Analysis of Large-scale Microservice Architectures"
+    badges: "Available,Functional"
+    artifact_url: "https://zenodo.org/record/6544915#.Yn3UZhPMJhE"
+  - title: "uKharon: A Membership Service for Microsecond Applications"
+    badges: "Functional,Reproduced"
+    repository_url: "https://github.com/LPD-EPFL/ukharon-artifacts"
+  - title: "Co-opting Linux Processes for High-Performance Network Simulation"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/netsim-atc2022/netsim-atc2022.github.io"
+  - title: "Vinter: Automatic Non-Volatile Memory Crash Consistency Testing for Full Systems"
+    badges: "Available,Functional,Reproduced"
+    artifact_url: "https://zenodo.org/record/6544869"
+  - title: "PilotFish: Harvesting Free Cycles of Cloud Gaming with Deep Learning Training"
+    badges: "Available"
+    repository_url: "https://github.com/Chen-Binghao/PilotFish"
+  - title: "Modulo: Finding Convergence Failure Bugs in Distributed Systems with Divergence Resync Models"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/Kaelus/Modulo"
+  - title: "Primo: Practical Learning-Augmented Systems with Interpretable Models"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/S-Lab-System-Group/Primo"
+  - title: "Towards Latency Awareness for Content Delivery Network Caching"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/GYan58/la-cache-atc22"
+  - title: "HyperEnclave: An Open and Cross-platform Trusted Execution Environment"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/HyperEnclave/atc22-ae"
+  - title: "Privbox: Faster System Calls Through Sandboxed Privileged Execution"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/privbox/devenv"
+  - title: "Help Rather Than Recycle: Alleviating Cold Startup in Serverless Computing Through Inter-Function Container Sharing"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/lzjzx1122/Pagurus"
+  - title: "SoftTRR: Protect Page Tables against Rowhammer Attacks using Software-only Target Row Refresh"
+    badges: "Available"
+    artifact_url: "https://doi.org/10.6084/m9.figshare.19721692"
+  - title: "Speculative Recovery: Cheap, Highly Available Fault Tolerance with Disaggregated Storage"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/princeton-sns/specreds"
+  - title: "CoVA: Exploiting Compressed-Domain Analysis to Accelerate Video Analytics"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/casys-kaist/CoVA"
+  - title: "AlNiCo: SmartNIC-accelerated Contention-aware Request Scheduling for Transaction Processing"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/thustorage/AlNiCo"
+  - title: "High Throughput Replication with Integrated Membership Management"
+    badges: "Available,Functional"
+    repository_url: "https://github.com/pfouto/chain"
+  - title: "Memory Harvesting in Multi-GPU Systems with Hierarchical Unified Virtual Memory"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/casys-kaist/HUVM"
+  - title: "Cachew: Machine Learning Input Data Processing as a Service"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/eth-easl/cachew_experiments"
+  - title: "Building Fault-Tolerant Distributed Systems with DepFast"
+    badges: "Available,Functional"
+    repository_url: "https://github.com/stonysystems/depfast-ae/tree/atc_ae"
+  - title: "Campo: A Cost-Aware and High-Performance Mixed Precision Optimizer for Neural Network Training"
+    badges: "Available"
+    repository_url: "https://gitee.com/sayounara/Campo_amp"
+  - title: "DVABatch: Diversity-aware Multi-Entry Multi-Exit Batching for Efficient Processing of DNN Services on GPUs"
+    badges: "Available"
+    repository_url: "https://github.com/sjtu-epcc/DVABatch"
+  - title: "Zero Overhead Monitoring for Cloud-native Infrastructure using RDMA"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/wwwzrb/zero-ae/tree/zero-ae"
+  - title: "ZNSwap: un-Block your Swap"
+    badges: "Available"
+    repository_url: "https://github.com/acsl-technion/znswap"
+  - title: "SOTER: Guarding Black-box Inference for General Neural Networks at the Edge"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/hku-systems/SOTER"
+  - title: "JITServer: Disaggregated Caching JIT Compiler for the JVM in the Cloud"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/AlexeyKhrabrov/jitserver-benchmarks"
+  - title: "TETRIS: Memory-efficient Serverless Inference through Tensor Sharing"
+    badges: "Available"
+    repository_url: "https://github.com/JelixLi/Tetris"
+
+
 ---
-
-
-<style>
-table th:first-of-type {
-    width: 60%;
-    margin-top:10px;
-    margin-bottom:10px;
-}
-table th:nth-of-type(2) {
-    width: 20%;
-    margin-top:10px;
-    margin-bottom:10px;
-}
-table th:nth-of-type(3) {
-    width: 20%;
-    margin-top:10px;
-    margin-bottom:10px;
-}
-
-table td {
-    padding:0.25em;
-}
-
-span#aa {
-    background-color:#f15c24;
-    color:#FFFFFF;
-    font-weight: bold;
-    display: inline-block;
-    margin: 0px 0px 0px 0px;
-    width:100%;
-}
-
-span#af {
-    background-color:#1274bb;
-    color:#FFFFFF;
-    font-weight: bold;
-    display: inline-block;
-    margin: 0px 0px 0px 0px;
-    width:100%;
-}
-
-span#rr {
-    background-color:#6c4099;
-    color:#FFFFFF;
-    font-weight: bold;
-    display: inline-block;
-    margin: 0px 0px 0px 0px;
-    width:100%;
-}
-
-</style>
 
 **Submissions**: 52 (81% of accepted papers)
 
@@ -62,56 +171,55 @@ span#rr {
 * 40 Artifact Functional
 * 31 Results Reproduced
 
-| Paper title | Awarded Badges | Available at |
-|:-----------:|:--------------:|:------------:|
-| [Zero-Change Object Transmission for Distributed Big Data Analytics]() | <span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | |
-| [Addrminer: A Comprehensive Global Active IPv6 Address Discovery System]() | <span id="aa">AVAILABLE</span> | [Github](https://github.com/AddrMiner/AddrMiner) |
-| [Meces: Latency-efficient Rescaling via Prioritized State Migration for Stateful Distributed Stream Processing Systems]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/ATC2022No63/Meces-Artifact) |
-| [BBQ: A Block-based Bounded Queue for Exchanging Data and Profiling]() | <span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | |
-| [Riker: Always-Correct and Fast Incremental Builds from Simple Specifications]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Zenodo](https://doi.org/10.5281/zenodo.6544966) |
-| [Secure and Lightweight Deduplicated Storage via Shielded Deduplication-Before-Encryption]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/yzr95924/DEBE) |
-| [CBMM: Financial Advice for Kernel Memory Managers]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span> | [Github](https://github.com/multifacet/cbmm-artifact) |
-| [IPLFS: Log-Structured File System without Garbage Collection]() | <span id="aa">AVAILABLE</span> | [Github1](https://github.com/ESOS-Lab/IPLFS)<br>[Github2](https://github.com/ESOS-Lab/Interval_Mapping) |
-| [EPK: Scalable and Efficient Memory Protection Key]() | <span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/SJTU-IPADS/EPK) |
-| [StRAID: Stripe-threaded Architecture for Parity-based RAIDs with Ultra-fast SSDs]() | <span id="aa">AVAILABLE</span> | [Github](https://github.com/wsczq1/straid) |
-| [Not that Simple: Email Delivery in the 21st Century]() | <span id="aa">AVAILABLE</span> | [Github](https://github.com/ichdasich/email-measurement-toolchain) |
-| [Pacman: An Efficient Compaction Approach for Log-Structured Key-Value Store on Persistent Memory]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/thustorage/pacman) |
-| [Serving Heterogeneous Machine Learning Models on Multi-GPU Servers with Spatio-Temporal Sharing]() | <span id="aa">AVAILABLE</span> | [Github](https://doi.org/10.5281/zenodo.6544909) |
-| [Investigating Managed Language Runtime Performance: Why JavaScript and Python are 8x and 29x slower than C++, yet Java and Go can be Faster?]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github1](https://github.com/dsrg-uoft/LangBench)<br>[Github2](https://github.com/dsrg-uoft/LangBench-openjdk)<br>[Github3](https://github.com/dsrg-uoft/LangBench-nodejs)<br>[Github4](https://github.com/dsrg-uoft/LangBench-cpython)|
-| [Sift: Using Refinement-guided Automation to Verify Complex Distributed Systems]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span> | [Github](https://github.com/GLaDOS-Michigan/Sift) |
-| [KRCORE: a microsecond-scale RDMA control plane for elastic computing]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/SJTU-IPADS/krcore-artifacts.git) |
-| [Faith: An Efficient Framework for Transformer Verification on GPUs]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/BoyuanFeng/Faith) |
-| [NVMe SSD Failures in the Field: the Fail-Stop and the Fail-Slow]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Tianchi](https://tianchi.aliyun.com/dataset/dataDetail?dataId=128972)<br>[Github](https://github.com/Excelsiorrr/AE) |
-| [FlatFS: Flatten Hierarchical File System Namespace on Non-volatile Memories]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/miaogecm/FlatFS.git) |
-| [PetS: A Unified Framework for Parameter-Efficient Transformers Serving]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span>| [Zenodo](https://zenodo.org/record/6534753#.YnpJtoxBz31) |
-| [RunD: A Lightweight Secure Container Runtime for High-density Deployment and High-concurrency Startup in Serverless Computing]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/chengjiagan/RunD_ATC22) |
-| [Building a High-performance Fine-grained Deduplication Framework for Backup Storage with High Deduplication Ratio]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span> | [Github](https://github.com/Borelset/MeGA) |
-| [Automatic Recovery of Fine-grained Compiler Artifacts at the Binary Level]() | <span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | |
-| [FpgaNIC: An FPGA-based Versatile 100Gb SmartNIC for GPUs]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br> | [Github](https://github.com/carlzhang4/FPGANic) |
-| [Whale: Efficient Giant Model Training over Heterogeneous GPUs]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span> | [Github](https://github.com/alibaba/EasyParallelLibrary) |
-| [Critical Path Analysis of Large-scale Microservice Architectures]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span> | [Zenodo](https://zenodo.org/record/6544915#.Yn3UZhPMJhE) |
-| [uKharon: A Membership Service for Microsecond Applications]() | <span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/LPD-EPFL/ukharon-artifacts) |
-| [Co-opting Linux Processes for High-Performance Network Simulation]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/netsim-atc2022/netsim-atc2022.github.io)<br>[Website](https://netsim-atc2022.github.io) |
-| [Vinter: Automatic Non-Volatile Memory Crash Consistency Testing for Full Systems]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Zenodo](https://zenodo.org/record/6544869) |
-| [PilotFish: Harvesting Free Cycles of Cloud Gaming with Deep Learning Training]() | <span id="aa">AVAILABLE</span> | [Github](https://github.com/Chen-Binghao/PilotFish) |
-| [Modulo: Finding Convergence Failure Bugs in Distributed Systems with Divergence Resync Models]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/Kaelus/Modulo) |
-| [Primo: Practical Learning-Augmented Systems with Interpretable Models]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/S-Lab-System-Group/Primo) |
-| [Towards Latency Awareness for Content Delivery Network Caching]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/GYan58/la-cache-atc22) |
-| [HyperEnclave: An Open and Cross-platform Trusted Execution Environment]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/HyperEnclave/atc22-ae) |
-| [Privbox: Faster System Calls Through Sandboxed Privileged Execution]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/privbox/devenv) |
-| [Help Rather Than Recycle: Alleviating Cold Startup in Serverless Computing Through Inter-Function Container Sharing]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/lzjzx1122/Pagurus) |
-| [SoftTRR: Protect Page Tables against Rowhammer Attacks using Software-only Target Row Refresh]() | <span id="aa">AVAILABLE</span> | [figshare](https://doi.org/10.6084/m9.figshare.19721692) |
-| [Speculative Recovery: Cheap, Highly Available Fault Tolerance with Disaggregated Storage]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/princeton-sns/specreds) |
-| [CoVA: Exploiting Compressed-Domain Analysis to Accelerate Video Analytics]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/casys-kaist/CoVA) |
-| [AlNiCo: SmartNIC-accelerated Contention-aware Request Scheduling for Transaction Processing]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/thustorage/AlNiCo) |
-| [High Throughput Replication with Integrated Membership Management]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span> | [Github1](https://github.com/pfouto/chain)<br>[Github2](https://github.com/pfouto/chain-client)<br>[Github3](https://github.com/pfouto/chain-zoo)<br>[Github4](https://github.com/pfouto/chain-results) |
-| [Memory Harvesting in Multi-GPU Systems with Hierarchical Unified Virtual Memory]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/casys-kaist/HUVM) |
-| [Cachew: Machine Learning Input Data Processing as a Service]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/eth-easl/cachew_experiments) |
-| [Building Fault-Tolerant Distributed Systems with DepFast]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span> | [Github](https://github.com/stonysystems/depfast-ae/tree/atc_ae) |
-| [Campo: A Cost-Aware and High-Performance Mixed Precision Optimizer for Neural Network Training]() | <span id="aa">AVAILABLE</span> | [Gitee](https://gitee.com/sayounara/Campo_amp) |
-| [DVABatch: Diversity-aware Multi-Entry Multi-Exit Batching for Efficient Processing of DNN Services on GPUs]() | <span id="aa">AVAILABLE</span> | [Github](https://github.com/sjtu-epcc/DVABatch) |
-| [Zero Overhead Monitoring for Cloud-native Infrastructure using RDMA]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/wwwzrb/zero-ae/tree/zero-ae) |
-| [ZNSwap: un-Block your Swap]() | <span id="aa">AVAILABLE</span> | [Github1](https://github.com/acsl-technion/znswap)<br>[Github2](https://github.com/acsl-technion/znswap_policy_module) |
-| [SOTER: Guarding Black-box Inference for General Neural Networks at the Edge]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/hku-systems/SOTER) |
-| [JITServer: Disaggregated Caching JIT Compiler for the JVM in the Cloud]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github1](https://github.com/AlexeyKhrabrov/jitserver-benchmarks)<br>[Github2](https://github.com/AlexeyKhrabrov/openj9/tree/atc22ae)<br>[Github3](https://github.com/AlexeyKhrabrov/omr/tree/atc22ae)<br>[Github4](https://github.com/AlexeyKhrabrov/openj9-openjdk-jdk8/tree/atc22ae) |
-| [TETRIS: Memory-efficient Serverless Inference through Tensor Sharing]() | <span id="aa">AVAILABLE</span> | [Github](https://github.com/JelixLi/Tetris) |
+<table>
+  <thead>
+    <tr>
+      <th>Paper</th>
+      <th width="75px">Avail.</th>
+      <th width="75px">Funct.</th>
+      <th width="75px">Repro.</th>
+      <th>Available At</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% assign sorted_artifacts = page.artifacts | sort: "title" %}
+  {% for artifact in sorted_artifacts %}
+    <tr>
+      <td>
+        {% if artifact.doi %}
+            <a href="{{artifact.doi}}" target="_blank">{{artifact.title}}</a>
+        {% else %}
+            {{ artifact.title }}
+        {% endif %}
+        {% if artifact.award %}
+          <br><b>{{ artifact.award }}</b>
+        {% endif %}
+      </td>
+      <td width="75px">
+        {% if artifact.badges contains "Available" %}
+          <img src="{{ site.baseurl }}/images/{{ page.available_img }}" alt="{{ page.available_name }}">
+        {% endif %}
+      </td>
+      <td width="75px">
+        {% if artifact.badges contains "Functional" %}
+          <img src="{{ site.baseurl }}/images/{{ page.functional_img }}" alt="{{ page.functional_name }}">
+        {% endif %}
+      </td>
+      <td width="75px">
+        {% if artifact.badges contains "Reproduced" %}
+          <img src="{{ site.baseurl }}/images/{{ page.reproduced_img }}" alt="{{ page.reproduced_name }}">
+        {% endif %}
+      </td>
+      <td width="120px">
+        {% if artifact.artifact_url %}
+          <a href="{{artifact.artifact_url}}" target="_blank">Artifact</a><br>
+        {% endif %} {% if artifact.repository_url %}
+          <a href="{{artifact.repository_url}}" target="_blank">Repository</a><br>
+        {% endif %} {% if artifact.appendix_url %}
+          <a href="{{artifact.appendix_url}}" target="_blank">Appendix</a><br>
+        {% endif %}
+      </td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>

--- a/_conferences/atc2023/results.md
+++ b/_conferences/atc2023/results.md
@@ -1,58 +1,136 @@
 ---
 title: Results
 order: 40
+available_img: "usenix_available.svg"
+available_name: "Artifacts Available"
+functional_img: "usenix_functional.svg"
+functional_name: "Artifacts Evaluated - Functional"
+reproduced_img: "usenix_reproduced.svg"
+reproduced_name: "Results Reproduced"
+
+artifacts:
+  - title: "Calcspar: A Contract-Aware LSM-Tree for Cloud Storage with Low Latency Spikes"
+    badges: "Available"
+    repository_url: "https://github.com/yhzhou-pds/ATC23-Calcspar.git"
+  - title: "SAGE: Software-based Attestation for GPU Execution"
+    badges: "Available,Functional"
+    repository_url: "https://github.com/spcl/sage"
+  - title: "Overcoming the Memory Wall with CXL-Enabled SSDs"
+    badges: "Available,Functional"
+    repository_url: "https://github.com/spypaul/MQSim_CXL.git"
+  - title: "UnFaaSener: Latency and Cost Aware Offloading of Functions from Serverless Platforms"
+    badges: "Available"
+    repository_url: "https://github.com/ubc-cirrus-lab/unfaasener"
+  - title: "Adaptive Online Cache Capacity Optimization via Lightweight Working Set Size Estimation at Scale"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/shadowcache/Cuki-Artifact-WSS-Estimation"
+  - title: "P2CACHE: Exploring Tiered Memory for In-Kernel File Systems Caching"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/YesZhen/P2CACHE.git"
+  - title: "Towards Iterative Relational Algebra on the GPU"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/harp-lab/usenixATC23/"
+  - title: "Nodens: Enabling Resource Efficient and Fast QoS Recovery of Dynamic Microservice Applications in Datacenters"
+    badges: "Available"
+    repository_url: "https://github.com/shijiuchen/Nodens"
+  - title: "Comosum: An Extensible, Reconfigurable, and Fault-Tolerant IoT Platform for Digital Agriculture"
+    badges: "Available,Functional,Reproduced"
+    artifact_url: "https://zenodo.org/badge/latestdoi/580583199"
+  - title: "TiDedup: A New Distributed Deduplication Architecture for Ceph"
+    badges: "Available,Functional"
+    repository_url: "https://github.com/ssdohammer-sl/ceph/tree/tidedup"
+  - title: "SecretFlow-SPU: A Performant and User-Friendly Framework for Privacy-Preserving Machine Learning"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/secretflow/spu/tree/atc23_ae"
+  - title: "AWARE: Automate Workload Autoscaling with Reinforcement Learning in Production Cloud Systems"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://gitlab.engr.illinois.edu/DEPEND/atc23-artifact-730"
+  - title: "Revisiting Secondary Indexing in LSM-based Storage Systems with Persistent Memory"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/thustorage/perseid"
+  - title: "GLogS: Interactive Graph Pattern Matching Query At Large Scale"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/MeloYang05/GLogS-Artifact"
+  - title: "Beware of Fragmentation: Scheduling GPU-Sharing Workloads with Fragmentation Gradient Descent"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/hkust-adsl/kubernetes-scheduler-simulator"
+  - title: "TC-GNN: Bridging Sparse GNN Computation and Dense Tensor Cores on GPUs"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/YukeWang96/TCGNN-Pytorch.git"
+  - title: "LLFree: Scalable and Optionally-Persistent Page-Frame Allocation"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/luhsra/llfree-bench/tree/atc23-artifact-eval/artifact-eval"
+  - title: "SOWalker: An I/O-Optimized Out-of-Core Graph Processing System for Second-Order Random Walks"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/tzphh/SOWalker"
+  - title: "MSRL: Distributed Reinforcement Learning with Dataflow Fragments"
+    badges: "Available,Functional"
+    repository_url: "https://github.com/mindspore-lab/mindrl"
+  - title: "Light-Dedup: A Light-weight Inline Deduplication Framework for Non-Volatile Memory File Systems"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/Light-Dedup/Light-Dedup"
+  - title: "Zhuque: Failure Isn't an Option, It's an Exception"
+    badges: "Available,Functional"
+    repository_url: "https://github.com/georgehodgkins/Zhuque_artifact"
+  - title: "oBBR: Optimize Retransmissions of BBR flows on the Internet"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/bpq233/oBBR"
+  - title: "VectorVisor: A Binary Translation Scheme for Throughput-Oriented GPU Acceleration"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/SamGinzburg/VectorVisor"
+  - title: "SmartMoE: Efficiently Training Sparsely-Activated Models through Combining Static and Dynamic Parallelization"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/thu-pacman/SmartMoE-AE"
+  - title: "Analysis and Optimization of Network I/O Tax in Confidential Virtual Machines"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/IPADS-Bifrost/ae-guide"
+  - title: "Legion: Automatically Pushing the Envelope of Multi-GPU System for Billion-Scale GNN Training"
+    badges: "Available,Functional"
+    repository_url: "https://github.com/JIESUN233/Legion"
+  - title: "Bridging the Gap between Relational OLTP and Graph-based OLAP"
+    badges: "Available"
+    repository_url: "https://github.com/SJTU-IPADS/vegito/tree/gart"
+  - title: "Portunus: Re-imagining Access Control in Distributed Systems"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/cloudflare/circl/tree/main/abe/cpabe/tkn20"
+  - title: "PINOLO: Detecting Logical Bugs in Database Management Systems with Approximate Query Synthesis"
+    badges: "Available,Functional"
+    repository_url: "https://github.com/qaqcatz/impomysql"
+  - title: "Translation Pass-Through for Near-Native Paging Performance in VMs"
+    badges: "Available,Functional"
+    repository_url: "https://github.com/acsl-technion/TPT"
+  - title: "Arbitor: A Numerically Accurate Hardware Emulation Tool for DNN Accelerators"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/arbitor-project/artifact"
+  - title: "Sponge: Fast Reactive Scaling for Stream Processing with Serverless Frameworks"
+    badges: "Available"
+    repository_url: "https://github.com/apache/incubator-nemo/tree/sponge"
+  - title: "MELF: Multivariant Executables for a Heterogeneous World"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://sra.uni-hannover.de/Publications/2023/melf-usenix-atc23/"
+  - title: "Avoiding the Ordering Trap in Systems Performance Measurement"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/ordersage/paper-artifact"
+  - title: "Oakestra: A Lightweight Hierarchical Orchestration Framework for Edge Computing"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://bit.ly/oakestra-artifacts"
+  - title: "Explore Data Placement Algorithm for Balanced Recovery Load Distribution"
+    badges: "Available,Functional"
+    repository_url: "https://github.com/rcstor/rcstor"
+  - title: "EnvPipe: Performance-preserving DNN Training Framework for Saving Energy"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/casys-kaist/EnvPipe"
+  - title: "FarReach: Write-back Caching in Programmable Switches"
+    badges: "Available,Functional"
+    repository_url: "https://github.com/LGN520/farreach-public"
+  - title: "MOSAIC Teaching Operating System Model and Checker"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/jiangyy/mosaic"
+  - title: "Luci: Loader-based Dynamic Software Updates for Off-the-shelf Shared Objects"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://gitlab.cs.fau.de/luci-project/eval-atc23"
+
 ---
-
-
-<style>
-table th:first-of-type {
-    width: 60%;
-    margin-top:10px;
-    margin-bottom:10px;
-}
-table th:nth-of-type(2) {
-    width: 20%;
-    margin-top:10px;
-    margin-bottom:10px;
-}
-table th:nth-of-type(3) {
-    width: 20%;
-    margin-top:10px;
-    margin-bottom:10px;
-}
-
-table td {
-    padding:0.25em;
-}
-
-span#aa {
-    background-color:#f15c24;
-    color:#FFFFFF;
-    font-weight: bold;
-    display: inline-block;
-    margin: 0px 0px 0px 0px;
-    width:100%;
-}
-
-span#af {
-    background-color:#1274bb;
-    color:#FFFFFF;
-    font-weight: bold;
-    display: inline-block;
-    margin: 0px 0px 0px 0px;
-    width:100%;
-}
-
-span#rr {
-    background-color:#6c4099;
-    color:#FFFFFF;
-    font-weight: bold;
-    display: inline-block;
-    margin: 0px 0px 0px 0px;
-    width:100%;
-}
-
-</style>
 
 **Submissions**: 41 (63% of accepted papers)
 
@@ -62,46 +140,55 @@ span#rr {
 * 36 Artifact Functional
 * 26 Results Reproduced
 
-| Paper title | Awarded Badges | Available at |
-|:-----------:|:--------------:|:------------:|
-| [Calcspar: A Contract-Aware LSM-Tree for Cloud Storage with Low Latency Spikes]() | <span id="aa">AVAILABLE</span> | [Github](https://github.com/yhzhou-pds/ATC23-Calcspar.git) |
-| [SAGE: Software-based Attestation for GPU Execution]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span> | [Github](https://github.com/spcl/sage) |
-| [Overcoming the Memory Wall with CXL-Enabled SSDs]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span> | [Github](https://github.com/spypaul/MQSim_CXL.git) |
-| [UnFaaSener: Latency and Cost Aware Offloading of Functions from Serverless Platforms]() | <span id="aa">AVAILABLE</span> | [Github](https://github.com/ubc-cirrus-lab/unfaasener) |
-| [Adaptive Online Cache Capacity Optimization via Lightweight Working Set Size Estimation at Scale]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span>| [Github](https://github.com/shadowcache/Cuki-Artifact-WSS-Estimation) <br> [APP](https://github.com/shadowcache/Cuki-Artifact-Presto) <br> [cache system](https://github.com/shadowcache/Cuki-Artifact-Alluxio) |
-| [P2CACHE: Exploring Tiered Memory for In-Kernel File Systems Caching]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span>| [Github](https://github.com/YesZhen/P2CACHE.git) |
-| [Towards Iterative Relational Algebra on the GPU]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span>| [Github](https://github.com/harp-lab/usenixATC23/) |
-| [Nodens: Enabling Resource Efficient and Fast QoS Recovery of Dynamic Microservice Applications in Datacenters]() | <span id="aa">AVAILABLE</span> | [Github](https://github.com/shijiuchen/Nodens) |
-| [Comosum: An Extensible, Reconfigurable, and Fault-Tolerant IoT Platform for Digital Agriculture]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span>| [Zenodo](https://zenodo.org/badge/latestdoi/580583199) |
-| [TiDedup: A New Distributed Deduplication Architecture for Ceph]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span> | [Github](https://github.com/ssdohammer-sl/ceph/tree/tidedup) |
-| [SecretFlow-SPU: A Performant and User-Friendly Framework for Privacy-Preserving Machine Learning]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span>| [Github](https://github.com/secretflow/spu/tree/atc23_ae) |
-| [AWARE: Automate Workload Autoscaling with Reinforcement Learning in Production Cloud Systems]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span>| [Github](https://gitlab.engr.illinois.edu/DEPEND/atc23-artifact-730) |
-| [Revisiting Secondary Indexing in LSM-based Storage Systems with Persistent Memory]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span>| [Github](https://github.com/thustorage/perseid) |
-| [GLogS: Interactive Graph Pattern Matching Query At Large Scale]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span>| [Github](https://github.com/MeloYang05/GLogS-Artifact) |
-| [Beware of Fragmentation: Scheduling GPU-Sharing Workloads with Fragmentation Gradient Descent]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span>| [Github](https://github.com/hkust-adsl/kubernetes-scheduler-simulator) |
-| [TC-GNN: Bridging Sparse GNN Computation and Dense Tensor Cores on GPUs]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span>| [Github](https://github.com/YukeWang96/TCGNN-Pytorch.git) |
-| [LLFree: Scalable and Optionally-Persistent Page-Frame Allocation]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span>| [Github](https://github.com/luhsra/llfree-bench/tree/atc23-artifact-eval/artifact-eval) |
-| [SOWalker: An I/O-Optimized Out-of-Core Graph Processing System for Second-Order Random Walks]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span>| [Github](https://github.com/tzphh/SOWalker) |
-| [MSRL: Distributed Reinforcement Learning with Dataflow Fragments]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span> | [Github](https://github.com/mindspore-lab/mindrl) |
-| [Light-Dedup: A Light-weight Inline Deduplication Framework for Non-Volatile Memory File Systems]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span>| https://github.com/Light-Dedup/Light-Dedup <br> https://github.com/Light-Dedup/nvm_tools <br> https://github.com/Light-Dedup/mcp <br> https://github.com/Light-Dedup/tests <br> https://github.com/Light-Dedup/nv-dedup |
-| [Zhuque: Failure Isn't an Option, It's an Exception]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span> | [Github](https://github.com/georgehodgkins/Zhuque_artifact) |
-| [oBBR: Optimize Retransmissions of BBR flows on the Internet]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span>| [Github](https://github.com/bpq233/oBBR) |
-| [VectorVisor: A Binary Translation Scheme for Throughput-Oriented GPU Acceleration]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span>| [Github](https://github.com/SamGinzburg/VectorVisor) |
-| [SmartMoE: Efficiently Training Sparsely-Activated Models through Combining Static and Dynamic Parallelization]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span>| [Github](https://github.com/thu-pacman/SmartMoE-AE) |
-| [Analysis and Optimization of Network I/O Tax in Confidential Virtual Machines]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span>| [Github](https://github.com/IPADS-Bifrost/ae-guide) |
-| [Legion: Automatically Pushing the Envelope of Multi-GPU System for Billion-Scale GNN Training]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span> | [Github](https://github.com/JIESUN233/Legion) |
-| [Bridging the Gap between Relational OLTP and Graph-based OLAP]() | <span id="aa">AVAILABLE</span> | [Github](https://github.com/SJTU-IPADS/vegito/tree/gart) |
-| [Portunus: Re-imagining Access Control in Distributed Systems]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span>| [Github](https://github.com/cloudflare/circl/tree/main/abe/cpabe/tkn20) |
-| [PINOLO: Detecting Logical Bugs in Database Management Systems with Approximate Query Synthesis]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span> | [Github](https://github.com/qaqcatz/impomysql) |
-| [Translation Pass-Through for Near-Native Paging Performance in VMs]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span> | [Github](https://github.com/acsl-technion/TPT) |
-| [Arbitor: A Numerically Accurate Hardware Emulation Tool for DNN Accelerators]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span>| [Github](https://github.com/arbitor-project/artifact) |
-| [Sponge: Fast Reactive Scaling for Stream Processing with Serverless Frameworks]() | <span id="aa">AVAILABLE</span> | [Github](https://github.com/apache/incubator-nemo/tree/sponge) |
-| [MELF: Multivariant Executables for a Heterogeneous World]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span>| [Github](https://sra.uni-hannover.de/Publications/2023/melf-usenix-atc23/) |
-| [Avoiding the Ordering Trap in Systems Performance Measurement]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span>| [Github](https://github.com/ordersage/paper-artifact) |
-| [Oakestra: A Lightweight Hierarchical Orchestration Framework for Edge Computing]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span>| [Github](https://bit.ly/oakestra-artifacts) |
-| [Explore Data Placement Algorithm for Balanced Recovery Load Distribution]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span> | [Benchmark](https://github.com/rcstor/greedy_microbenchmark) <br> [Github](https://github.com/rcstor/rcstor) |
-| [EnvPipe: Performance-preserving DNN Training Framework for Saving Energy]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span>| [Github](https://github.com/casys-kaist/EnvPipe) |
-| [FarReach: Write-back Caching in Programmable Switches]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span> | [Github](https://github.com/LGN520/farreach-public) |
-| [MOSAIC Teaching Operating System Model and Checker]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span>| [Github](https://github.com/jiangyy/mosaic) |
-| [Luci: Loader-based Dynamic Software Updates for Off-the-shelf Shared Objects]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span>| [GitLab](https://gitlab.cs.fau.de/luci-project/eval-atc23) <br> [GitLab](https://github.com/luci-project/eval-atc23) <br> [VM](https://sys.cs.fau.de/research/data/luci/atc23/ubuntu.ova) |
-| [LPNS: Scalable and Latency-Predictable Local Storage Virtualization for Unpredictable NVMe SSDs in Clouds]() | <span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span>| |
+<table>
+  <thead>
+   <tr>
+    <th>Paper</th>
+    <th width="75px">Avail.</th>
+    <th width="75px">Funct.</th>
+    <th width="75px">Repro.</th>
+    <th>Available At</th>
+   </tr>
+  </thead>
+  <tbody>
+  {% assign sorted_artifacts = page.artifacts | sort: "title" %}
+  {% for artifact in sorted_artifacts %}
+   <tr>
+    <td>
+      {% if artifact.doi %}
+        <a href="{{artifact.doi}}" target="_blank">{{artifact.title}}</a>
+      {% else %}
+        {{ artifact.title }}
+      {% endif %}
+      {% if artifact.award %}
+       <br><b>{{ artifact.award }}</b>
+      {% endif %}
+    </td>
+    <td width="75px">
+      {% if artifact.badges contains "Available" %}
+       <img src="{{ site.baseurl }}/images/{{ page.available_img }}" alt="{{ page.available_name }}">
+      {% endif %}
+    </td>
+    <td width="75px">
+      {% if artifact.badges contains "Functional" %}
+       <img src="{{ site.baseurl }}/images/{{ page.functional_img }}" alt="{{ page.functional_name }}">
+      {% endif %}
+    </td>
+    <td width="75px">
+      {% if artifact.badges contains "Reproduced" %}
+       <img src="{{ site.baseurl }}/images/{{ page.reproduced_img }}" alt="{{ page.reproduced_name }}">
+      {% endif %}
+    </td>
+    <td width="120px">
+      {% if artifact.artifact_url %}
+       <a href="{{artifact.artifact_url}}" target="_blank">Artifact</a><br>
+      {% endif %} {% if artifact.repository_url %}
+       <a href="{{artifact.repository_url}}" target="_blank">Repository</a><br>
+      {% endif %} {% if artifact.appendix_url %}
+       <a href="{{artifact.appendix_url}}" target="_blank">Appendix</a><br>
+      {% endif %}
+    </td>
+   </tr>
+  {% endfor %}
+  </tbody>
+</table>

--- a/_conferences/atc2024/results.md
+++ b/_conferences/atc2024/results.md
@@ -1,11 +1,11 @@
 ---
 title: Results
 order: 40
-available_img: "usenix-available.svg"
+available_img: "usenix_available.svg"
 available_name: "Artifacts Available"
-functional_img: "usenix-functional.svg"
+functional_img: "usenix_functional.svg"
 functional_name: "Artifacts Evaluated - Functional"
-reproduced_img: "usenix-reproduced.svg"
+reproduced_img: "usenix_reproduced.svg"
 reproduced_name: "Results Reproduced"
 
 artifacts:

--- a/_conferences/atc2024/results.md
+++ b/_conferences/atc2024/results.md
@@ -1,58 +1,160 @@
 ---
 title: Results
 order: 40
+available_img: "usenix-available.svg"
+available_name: "Artifacts Available"
+functional_img: "usenix-functional.svg"
+functional_name: "Artifacts Evaluated - Functional"
+reproduced_img: "usenix-reproduced.svg"
+reproduced_name: "Results Reproduced"
+
+artifacts:
+  - title: "Massively Parallel Multi-Versioned Transaction Processing"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/ShujianQian/epic-artifact"
+  - title: "Pecan: Cost-Efficient ML Data Preprocessing with Automatic Transformation Ordering and Hybrid Placement"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/eth-easl/pecan-experiments"
+  - title: "Efficient Decentralized Federated Singular Vector Decomposition"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/Di-Chai/Excalibur"
+  - title: "XCommit: resource-efficient, performant and cost-effective file system journaling"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/harshadjs/fast-commit-atc-2024"
+  - title: "TileClipper: Lightweight Selection of Regions of Interest from Videos for Traffic Surveillance"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/shubhamchdhary/TileClipper"
+    artifact_url: "https://doi.org/10.5281/zenodo.11179900"
+  - title: "A Tale of Two Paths: Toward a Hybrid Data Plane for Efﬁcient Far-Memory Applications"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/FereX98/atlas-ae/tree/main"
+  - title: "Starburst: A Cost-aware Scheduler for Cloud Bursting"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/michaelzhiluo/starburst"
+  - title: "Kivi: Verifying Cluster Management Systems"
+    badges: "Available"
+    repository_url: "https://github.com/bingzheliu/Kivihttps://github.com/gangmuk/k8s-failure-reproduction"
+  - title: "TeleScale: Telemetry for Gargantuan Memory Footprint Applications"
+    badges: "Available,Functional	"
+    artifact_url: "https://doi.org/10.5281/zenodo.11188652"
+  - title: "Removing Obstacles before Breaking Through the Memory Wall: A Close Look at HBM Errors in the Field"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/wrl297/Calchas"
+  - title: "Exploit both SMART Attributes and NAND Flash Wear Characteristics to Effectively Forecast SSD-based Storage Failures in Clusters"
+    badges: "Available,Functional"
+    repository_url: "https://github.com/SJTU-Storage-Lab/USENIX-ATC-2024-AE-APTN"
+  - title: "gVulkan: Scalable GPU Pooling for Pixel-Grained Rendering in Ray Tracing"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/funnygyc/gVulkan-artifact"
+  - title: "Opportunities and Limitations of Modern Hardware Isolation Mechanisms"
+    badges: "Available"
+    repository_url: "https://github.com/mars-research/atc24-artifact"
+  - title: "Efficient Large Graph Processing with Chunk-Based Graph Representation Model"
+    badges: "Available,Functional	"
+    artifact_url: "https://zenodo.org/doi/10.5281/zenodo.11181584"
+  - title: "A Secure, Fast, and Resource-Efficient Serverless Platform with Function REWIND"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/s3yonsei/rewind_serverless/tree/main/atc24_ae"
+  - title: "UniMem: Redesigning Disaggregated Memory within A Unified Local-Remote Memory Hierarchy"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/YeYan0304/UniMem-artifact"
+  - title: "Ethane: An Asymmetric File System for Disaggregated Persistent Memory"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/miaogecm/Ethane.git"
+  - title: "Taming Hot Bloat Under Virtualization with HugeScope"
+    badges: "Available,Functional"
+    repository_url: "https://github.com/TELOS-syslab/hugescope-atc23-ae"
+  - title: "Making Memory Management Extensible With Filesystems"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/multifacet/fbmm-artifact"
+  - title: "Evaluating Chiplet-based Large-Scale Interconnection Networks via Cycle-Accurate Packet-Parallel Simulation"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/Yinxiao-Feng/chiplet-network-sim/releases/tag/ae"
+  - title: "HiP4-UPF: Towards High-Performance Comprehensive 5G User Plane Function on P4 Programmable Switches"
+    badges: "Available	"
+  - title: "PeRF: Preemption-enabled RDMA Framework"
+    badges: "Available,Functional"
+    repository_url: "https://github.com/acryl-aaai/perf"
+  - title: "ExtMem: Enabling Application-Aware Memory Page Placement Policies"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/SepehrDV2/ExtMem"
+  - title: "SlimArchive: A Lightweight Architecture for Ethereum Archive Nodes"
+    badges: "Available,Functional	"
+  - title: "Accelerating the Training of Large Language Models using Efficient Activation Rematerialization and Optimal Hybrid Parallelism"
+    badges: "Available,Functional"
+    repository_url: "https://github.com/kwai/Megatron-Kwai/tree/atc24ae/examples/atc24"
+  - title: "DeepVisor: Effective Operator Graph Instantiation for Deep Learning by Execution State Monitoring"
+    badges: "Available,Functional,Reproduced	https://github.com/heheda12345/frontendhttps://github.com/heheda12345/frontend-AE"
+  - title: "High-density Mobile Cloud Gaming on Edge SoC Farms"
+    badges: "Available"
+    repository_url: "https://github.com/lizhang20/SFG"
+  - title: "FwdFL: Efficient Federated Finetuning of Language Models"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/UbiquitousLearning/FwdLLM"
+  - title: " Power-aware Deep Learning Model Serving with μ-Serve"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://gitlab.engr.illinois.edu/DEPEND/power-aware-model-serving"
+  - title: "Mangosteen: Fast Transparent Durability for Linearizable Applications using NVM"
+    badges: "Available,Functional	"
+  - title: "Identifying On-/Off-CPU Bottlenecks Together with Blocked Samples"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/s3yonsei/blocked_samples/"
+  - title: "OSMOSIS: Enabling Multi-Tenancy in Datacenter SmartNICs"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://spclgitlab.ethz.ch/mkhalilov/pspin-osmosis"
+  - title: "SimEnc: A High-Performance Similarity-Preserving Encryption Approach for Deduplication of Encrypted Docker Images"
+    badges: "Available,Functional"
+    repository_url: "https://github.com/suntong30/SimEnc"
+  - title: "Every Mapping Counts in Large Amounts: Folio Accounting"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://gitlab.com/foliomap_paper/ae"
+  - title: "Fast (Trapless) Kernel Probes Everywhere"
+    badges: "Available,Functional"
+    repository_url: "https://github.com/hardos-ebpf-fuzzing/atc24-uno-kprobe"
+  - title: "Balancing Analysis Time and Bug Detection: Daily Development-friendly Bug Detection in Linux"
+    badges: ""
+    repository_url: "https://github.com/sslab-keio/FiTx"
+  - title: "Monarch: A Fuzzing Framework for Distributed File Systems"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/rs3lab/Monarch"
+  - title: "Expeditious High-Concurrency MicroVM SnapStart in Persistent Memory with an Augmented Hypervisor"
+    badges: "Available"
+    repository_url: "https://github.com/DISCOPASS/PASS"
+  - title: "vFPIO: A Virtual I/O Abstraction for FPGA-accelerated I/O Devices"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/TUM-DSE/vFPIO"
+  - title: "Full Lifecycle Data Analysis on a Large-scale and Leadership Supercomputer: What Can We Learn from It?"
+    badges: "Available"
+    repository_url: "https://github.com/Beaconsys/Data_review_reporting"
+  - title: "ScalaAFA: Constructing User-Space All-Flash Array Engine with Holistic Designs"
+    badges: "Available,Functional"
+    repository_url: "https://github.com/ChaseLab-PKU/ScalaAFA"
+  - title: "Quant-LLM: Accelerating the Serving of Large Language Models via FP6-Centric Algorithm-System Co-Design on Modern GPUs"
+    badges: "Available"
+    repository_url: "https://github.com/usyd-fsalab/fp6_llm/"
+  - title: "StreamCache: Revisiting Page Cache for File Scanning on Fast Storage Devices"
+    badges: "Available,Functional,Reproduced"
+    artifact_url: "https://zenodo.org/records/11180773"
+  - title: "An Empirical Study of Rust-for-Linux: The Success, Dissatisfaction, and Compromise"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/Richardhongyu/rfl_empirical_tools"
+  - title: "ALPS: An Adaptive Learning, Priority OS Scheduler for Serverless Functions"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/fishercht1995/ALPS"
+    artifact_url: "https://zenodo.org/doi/10.5281/zenodo.11181953"
+  - title: "More is Different: Prototyping and Analyzing a New Form of Edge Server with Massive Mobile SoCs"
+    badges: "Available"
+    repository_url: "https://github.com/SoC-Cluster/SoC-Cluster-artifacts"
+  - title: "RL-Watchdog: A Fast and Predictable SSD Liveness Watchdog on Storage Systems"
+    badges: "Available	"
+  - title: "PUZZLE: Efficiently Aligning Large Language Models through Light-Weight Context Switch"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/kinman0224/PUZZLE-AE/tree/main"
+  - title: "mmTLS: Scaling the Performance of Encrypted Network Traffic Inspection"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/TNET-SNU/mmTLS"
+
 ---
-
-
-<style>
-table th:first-of-type {
-    width: 60%;
-    margin-top:10px;
-    margin-bottom:10px;
-}
-table th:nth-of-type(2) {
-    width: 20%;
-    margin-top:10px;
-    margin-bottom:10px;
-}
-table th:nth-of-type(3) {
-    width: 20%;
-    margin-top:10px;
-    margin-bottom:10px;
-}
-
-table td {
-    padding:0.25em;
-}
-
-span#aa {
-    background-color:#f15c24;
-    color:#FFFFFF;
-    font-weight: bold;
-    display: inline-block;
-    margin: 0px 0px 0px 0px;
-    width:100%;
-}
-
-span#af {
-    background-color:#1274bb;
-    color:#FFFFFF;
-    font-weight: bold;
-    display: inline-block;
-    margin: 0px 0px 0px 0px;
-    width:100%;
-}
-
-span#rr {
-    background-color:#6c4099;
-    color:#FFFFFF;
-    font-weight: bold;
-    display: inline-block;
-    margin: 0px 0px 0px 0px;
-    width:100%;
-}
-
-</style>
 
 **Submissions**: 49 (64% of accepted papers)
 
@@ -62,54 +164,48 @@ span#rr {
 * 39 Artifact Functional
 * 29 Results Reproduced
 
-| Paper title | Awarded Badges | Available at |
-|:-----------:|:--------------:|:------------:|
-| [Massively Parallel Multi-Versioned Transaction Processing]() |  <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/ShujianQian/epic-artifact) |
-| [Pecan: Cost-Efficient ML Data Preprocessing with Automatic Transformation Ordering and Hybrid Placement]() |  <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/eth-easl/pecan-experiments) |
-| [Efficient Decentralized Federated Singular Vector Decomposition]() |  <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/Di-Chai/Excalibur) |
-| [XCommit: resource-efficient, performant and cost-effective file system journaling]() |  <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/harshadjs/fast-commit-atc-2024) |
-| [TileClipper: Lightweight Selection of Regions of Interest from Videos for Traffic Surveillance]() |  <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/shubhamchdhary/TileClipper)<br>[Zenodo](https://doi.org/10.5281/zenodo.11179900) |
-| [A Tale of Two Paths: Toward a Hybrid Data Plane for Efﬁcient Far-Memory Applications]() |  <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/FereX98/atlas-ae/tree/main) |
-| [Starburst: A Cost-aware Scheduler for Cloud Bursting]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/michaelzhiluo/starburst) |
-| [Kivi: Verifying Cluster Management Systems]() | <span id="aa">AVAILABLE</span> | https://github.com/bingzheliu/Kivi<br>https://github.com/gangmuk/k8s-failure-reproduction |
-| [TeleScale: Telemetry for Gargantuan Memory Footprint Applications]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span> | [Zenode](https://doi.org/10.5281/zenodo.11188652) |
-| [Removing Obstacles before Breaking Through the Memory Wall: A Close Look at HBM Errors in the Field]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/wrl297/Calchas) |
-| [Exploit both SMART Attributes and NAND Flash Wear Characteristics to Effectively Forecast SSD-based Storage Failures in Clusters]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span> | [Github](https://github.com/SJTU-Storage-Lab/USENIX-ATC-2024-AE-APTN)<br>[Docker Image](https://github.com/SJTU-Storage-Lab/USENIX-ATC-2024-AE-APTN/tree/main/ContainerImage) |
-| [gVulkan: Scalable GPU Pooling for Pixel-Grained Rendering in Ray Tracing]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | https://github.com/funnygyc/gVulkan-artifact<br>https://github.com/funnygyc/RayTracingInVulkan-pureraytracing<br>The password for all zips in https://github.com/funnygyc/gVulkan-artifact is: gVulkan@atc2024 |
-| [Opportunities and Limitations of Modern Hardware Isolation Mechanisms]() |  <span id="aa">AVAILABLE</span> | [Github](https://github.com/mars-research/atc24-artifact) |
-| [Efficient Large Graph Processing with Chunk-Based Graph Representation Model]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span> | [Zenodo](https://zenodo.org/doi/10.5281/zenodo.11181584) |
-| [A Secure, Fast, and Resource-Efficient Serverless Platform with Function REWIND]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/s3yonsei/rewind_serverless/tree/main/atc24_ae) |
-| [UniMem: Redesigning Disaggregated Memory within A Unified Local-Remote Memory Hierarchy]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/YeYan0304/UniMem-artifact) |
-| [Ethane: An Asymmetric File System for Disaggregated Persistent Memory]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/miaogecm/Ethane.git) |
-| [Taming Hot Bloat Under Virtualization with HugeScope]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span> | [Github](https://github.com/TELOS-syslab/hugescope-atc23-ae) |
-| [Making Memory Management Extensible With Filesystems]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/multifacet/fbmm-artifact) |
-| [Evaluating Chiplet-based Large-Scale Interconnection Networks via Cycle-Accurate Packet-Parallel Simulation]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/Yinxiao-Feng/chiplet-network-sim/releases/tag/ae) |
-| [HiP4-UPF: Towards High-Performance Comprehensive 5G User Plane Function on P4 Programmable Switches]() | <span id="aa">AVAILABLE</span> |  |
-| [PeRF: Preemption-enabled RDMA Framework]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span> | [Github](https://github.com/acryl-aaai/perf) |
-| [ExtMem: Enabling Application-Aware Memory Page Placement Policies]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/SepehrDV2/ExtMem) |
-| [SlimArchive: A Lightweight Architecture for Ethereum Archive Nodes]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span> |  |
-| [Accelerating the Training of Large Language Models using Efficient Activation Rematerialization and Optimal Hybrid Parallelism]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span> | [Github](https://github.com/kwai/Megatron-Kwai/tree/atc24ae/examples/atc24) |
-| [DeepVisor: Effective Operator Graph Instantiation for Deep Learning by Execution State Monitoring]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | https://github.com/heheda12345/frontend<br>https://github.com/heheda12345/frontend-AE |
-| [High-density Mobile Cloud Gaming on Edge SoC Farms]() | <span id="aa">AVAILABLE</span> | [Github](https://github.com/lizhang20/SFG) |
-| [FwdFL: Efficient Federated Finetuning of Language Models]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/UbiquitousLearning/FwdLLM) |
-| [ Power-aware Deep Learning Model Serving with μ-Serve]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Gitlab](https://gitlab.engr.illinois.edu/DEPEND/power-aware-model-serving) |
-| [Mangosteen: Fast Transparent Durability for Linearizable Applications using NVM]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span> |  |
-| [Identifying On-/Off-CPU Bottlenecks Together with Blocked Samples]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/s3yonsei/blocked_samples/) |
-| [OSMOSIS: Enabling Multi-Tenancy in Datacenter SmartNICs]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Gitlab](https://spclgitlab.ethz.ch/mkhalilov/pspin-osmosis) |
-| [SimEnc: A High-Performance Similarity-Preserving Encryption Approach for Deduplication of Encrypted Docker Images]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span> | [Github](https://github.com/suntong30/SimEnc) |
-| [Every Mapping Counts in Large Amounts: Folio Accounting]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Gitlab](https://gitlab.com/foliomap_paper/ae) |
-| [Fast (Trapless) Kernel Probes Everywhere]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span> | [Github](https://github.com/hardos-ebpf-fuzzing/atc24-uno-kprobe) |
-| [Balancing Analysis Time and Bug Detection: Daily Development-friendly Bug Detection in Linux]() | | [Github](https://github.com/sslab-keio/FiTx) |
-| [Monarch: A Fuzzing Framework for Distributed File Systems]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/rs3lab/Monarch) |
-| [Expeditious High-Concurrency MicroVM SnapStart in Persistent Memory with an Augmented Hypervisor]() | <span id="aa">AVAILABLE</span> | [Github](https://github.com/DISCOPASS/PASS) |
-| [vFPIO: A Virtual I/O Abstraction for FPGA-accelerated I/O Devices]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/TUM-DSE/vFPIO) |
-| [Full Lifecycle Data Analysis on a Large-scale and Leadership Supercomputer: What Can We Learn from It?]() | <span id="aa">AVAILABLE</span> | [Github](https://github.com/Beaconsys/Data_review_reporting) |
-| [ScalaAFA: Constructing User-Space All-Flash Array Engine with Holistic Designs]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span> | [Github](https://github.com/ChaseLab-PKU/ScalaAFA) |
-| [Quant-LLM: Accelerating the Serving of Large Language Models via FP6-Centric Algorithm-System Co-Design on Modern GPUs]() | <span id="aa">AVAILABLE</span> | [Github](https://github.com/usyd-fsalab/fp6_llm/) |
-| [StreamCache: Revisiting Page Cache for File Scanning on Fast Storage Devices]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Zenodo](https://zenodo.org/records/11180773) |
-| [An Empirical Study of Rust-for-Linux: The Success, Dissatisfaction, and Compromise]() |  <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/Richardhongyu/rfl_empirical_tools) |
-| [ALPS: An Adaptive Learning, Priority OS Scheduler for Serverless Functions]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/fishercht1995/ALPS)<br>[Zenodo](https://zenodo.org/doi/10.5281/zenodo.11181953) |
-| [More is Different: Prototyping and Analyzing a New Form of Edge Server with Massive Mobile SoCs]() | <span id="aa">AVAILABLE</span> | [Github](https://github.com/SoC-Cluster/SoC-Cluster-artifacts) |
-| [RL-Watchdog: A Fast and Predictable SSD Liveness Watchdog on Storage Systems]() | <span id="aa">AVAILABLE</span> | |
-| [PUZZLE: Efficiently Aligning Large Language Models through Light-Weight Context Switch]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/kinman0224/PUZZLE-AE/tree/main) |
-| [mmTLS: Scaling the Performance of Encrypted Network Traffic Inspection]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/TNET-SNU/mmTLS) |
+<table>
+  <thead>
+    <tr>
+      <th>Paper</th>
+      <th width="75px">Avail.</th>
+      <th width="75px">Funct.</th>
+      <th width="75px">Repro.</th>
+      <th>Available At</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% assign sorted_artifacts = page.artifacts | sort: "title" %}
+  {% for artifact in sorted_artifacts %}
+    <tr>
+      <td>
+        {{ artifact.title }}
+      </td>
+      <td width="75px">
+        {% if artifact.badges contains "Available" %}
+          <img src="{{ site.baseurl }}/images/{{ page.available_img }}" alt="{{ page.available_name }}">
+        {% endif %}
+      </td>
+      <td width="75px">
+        {% if artifact.badges contains "Functional" %}
+          <img src="{{ site.baseurl }}/images/{{ page.functional_img }}" alt="{{ page.functional_name }}">
+        {% endif %}
+      </td>
+      <td width="75px">
+        {% if artifact.badges contains "Reproduced" %}
+          <img src="{{ site.baseurl }}/images/{{ page.reproduced_img }}" alt="{{ page.reproduced_name }}">
+        {% endif %}
+      </td>
+      <td width="120px">
+        {% if artifact.artifact_url %}
+          <a href="{{artifact.artifact_url}}" target="_blank">Artifact</a><br>
+        {% endif %} {% if artifact.repository_url %}
+          <a href="{{artifact.repository_url}}" target="_blank">Repository</a><br>
+        {% endif %} {% if artifact.appendix_url %}
+          <a href="{{artifact.appendix_url}}" target="_blank">Appendix</a><br>
+        {% endif %}
+      </td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>

--- a/_conferences/osdi2020/results.md
+++ b/_conferences/osdi2020/results.md
@@ -1,57 +1,210 @@
 ---
 title: Results
 order: 40
+available_img: "usenix_available.svg"
+available_name: "Artifacts Available"
+functional_img: "usenix_functional.svg"
+functional_name: "Artifacts Evaluated - Functional"
+reproduced_img: "usenix_reproduced.svg"
+reproduced_name: "Results Reproduced"
+
+artifacts:
+  - title: "Testing Database Engines via Pivoted Query Synthesis"
+    doi: "https://www.usenix.org/conference/osdi20/presentation/rigger"
+    award: "Distinguished Artifact Award"
+    badges: "Available,Functional,Reproduced"
+    artifact_url: "http://doi.org/10.5281/zenodo.4005705"
+  - title: "Specification and verification in the field: Applying formal methods to BPF just-in-time compilers in the Linux kernel"
+    doi: "https://www.usenix.org/conference/osdi20/presentation/nelson"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/uw-unsat/jitterbug/tree/osdi20-artifact"
+  - title: "RackSched: A Microsecond-Scale Scheduler for Rack-Scale Computers"
+    doi: "https://www.usenix.org/conference/osdi20/presentation/zhu"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/netx-repo/RSCS"
+  - title: "Overload Control for µs-scale RPCs with Breakwater"
+    doi: "https://www.usenix.org/conference/osdi20/presentation/cho"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/joshuafried/caladan-ae/tree/osdi20ae/breakwater"
+  - title: "Gauntlet: Finding Bugs in Compilers for Programmable Packet Processing"
+    doi: "https://www.usenix.org/conference/osdi20/presentation/ruffy"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/p4gauntlet/gauntlet/tree/aec"
+  - title: "AGAMOTTO: How Persistent is your Persistent Memory Application?"
+    doi: "https://www.usenix.org/conference/osdi20/presentation/neal"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/efeslab/agamotto/tree/artifact-eval-osdi20/artifact"
+  - title: "FIRM: An Intelligent Fine-grained Resource Management Framework for SLO-Oriented Microservices"
+    doi: "https://www.usenix.org/conference/osdi20/presentation/qiu"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://gitlab.engr.illinois.edu/DEPEND/firm"
+  - title: "SafetyPin: Encrypted Backups with Human-Memorable Secrets"
+    doi: "https://www.usenix.org/conference/osdi20/presentation/dauterman-safetypin"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/edauterman/SafetyPin"
+  - title: "DORY: An Encrypted Search System with Distributed Trust"
+    doi: "https://www.usenix.org/conference/osdi20/presentation/dauterman-dory"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/ucbrise/dory"
+  - title: "A Unified Architecture for Accelerating Distributed DNN Training in Heterogeneous GPU/CPU Clusters"
+    doi: "https://www.usenix.org/conference/osdi20/presentation/jiang"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/bytedance/byteps/"
+  - title: "hXDP: Efficient Software Packet Processing on FPGA NICs"
+    doi: "https://www.usenix.org/conference/osdi20/presentation/brunella"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/axbryd/hXDP-Artifacts/tree/camera-ready-v2.0"
+  - title: "Fault-tolerant and transactional stateful serverless workflows"
+    doi: "https://www.usenix.org/conference/osdi20/presentation/zhang-haoran"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/eniac/Beldi"
+  - title: "From WiscKey to Bourbon: A Learned Index for Log-Structured Merge Trees"
+    doi: "https://www.usenix.org/conference/osdi20/presentation/dai"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://bitbucket.org/daiyifandanny/learned-leveldb/src/master/"
+  - title: "AIFM: High-Performance, Application-Integrated Far Memory"
+    doi: "https://www.usenix.org/conference/osdi20/presentation/ruan"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/zainryan/AIFM-AE"
+  - title: "Toward a Generic Fault Tolerance Technique for Partial Network Partitioning"
+    doi: "https://www.usenix.org/conference/osdi20/presentation/alfatafta"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/UWASL/NIFTY"
+  - title: "Achieving 100Gbps Intrusion Prevention on a Single Server"
+    doi: "https://www.usenix.org/conference/osdi20/presentation/zhao-zhipeng"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/cmu-snap/pigasus"
+  - title: "Serving DNNs like Clockwork: Performance Predictability from the Bottom Up"
+    doi: "https://www.usenix.org/conference/osdi20/presentation/gujarati"
+    award: "Distinguished Artifact Award"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://gitlab.mpi-sws.org/cld/ml/clockwork/-/tree/osdi_2020_ae"
+  - title: "Storage Systems are Distributed Systems, So Verify Them That Way!"
+    doi: "https://www.usenix.org/conference/osdi20/presentation/hance"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/secure-foundations/veribetrkv-osdi2020"
+  - title: "Pegasus: Tolerating Skewed Workloads in Distributed Storage with In-Network Coherence Directories"
+    doi: "https://www.usenix.org/conference/osdi20/presentation/li-jialin"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/NUS-Systems-Lab/pegasus.git"
+  - title: "Byzantine Ordered Consensus without Byzantine Oligarchy"
+    doi: "https://www.usenix.org/conference/osdi20/presentation/zhang-yunhao"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/yhzhang0128/osdi20-artifact-evaluation"
+  - title: "Rammer: Enabling Holistic Deep Learning Compiler Optimizations with rTasks"
+    doi: "https://www.usenix.org/conference/osdi20/presentation/ma"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/microsoft/nnfusion/tree/osdi20_artifact/artifacts"
+  - title: "A Simpler and Faster NIC Driver Model for Network Functions"
+    doi: "https://www.usenix.org/conference/osdi20/presentation/pirelli"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/dslab-epfl/tinynf"
+  - title: "Caladan: Mitigating Interference at Microsecond Timescales"
+    doi: "https://www.usenix.org/conference/osdi20/presentation/fried"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/joshuafried/caladan-artifact"
+  - title: "Efficiently Mitigating Transient Execution Attacks using the Unmapped Speculation Contract"
+    doi: "https://www.usenix.org/conference/osdi20/presentation/behrens"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/mit-pdos/ward"
+  - title: "PANIC: A High-Performance Programmable NIC for Multi-tenant Networks"
+    doi: "https://www.usenix.org/conference/osdi20/presentation/lin"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://bitbucket.org/uw-madison-networking-research/panic_osdi20_artifact/src/master/"
+  - title: "Performance-Optimal Read-Only Transactions"
+    doi: "https://www.usenix.org/conference/osdi20/presentation/lu"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/princeton-sns/Eiger-PORT"
+  - title: "Retiarii: A Deep Learning Exploratory-Training Framework"
+    doi: "https://www.usenix.org/conference/osdi20/presentation/zhang-quanlu"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/microsoft/nni/tree/retiarii_artifact"
+  - title: "Fast RDMA-based Ordered Key-Value Store using Remote Learned Cache"
+    doi: "https://www.usenix.org/conference/osdi20/presentation/wei"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/SJTU-IPADS/xstore/tree/legacy"
+  - title: "Determinizing Crash Behavior with a Verified Snapshot-Consistent Flash Translation Layer"
+    doi: "https://www.usenix.org/conference/osdi20/presentation/chang"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/yunshengtw/scftl"
+  - title: "PACEMAKER: Avoiding HeART attacks in storage clusters with disk-adaptive redundancy"
+    doi: "https://www.usenix.org/conference/osdi20/presentation/kadekodi"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/saurabhkadekodi/preact-osdi-2020-artifact"
+  - title: "Ansor: Generating High-Performance Tensor Programs for Deep Learning"
+    doi: "https://www.usenix.org/conference/osdi20/presentation/zheng"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://bitbucket.org/lmzheng/ansor-artifact/src/master/"
+  - title: "Do OS abstractions make sense on FPGAs?"
+    doi: "https://www.usenix.org/conference/osdi20/presentation/roscoe"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/fpgasystems/Coyote"
+  - title: "Orchard: Differentially Private Analytics at Scale"
+    doi: "https://www.usenix.org/conference/osdi20/presentation/roth"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/edoroth/orchard"
+  - title: "A Tensor Compiler for Unified Machine Learning Prediction Serving"
+    doi: "https://www.usenix.org/conference/osdi20/presentation/nakandala"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/microsoft/hummingbird/commit/dbebbb715e7050b47895082664adc27f8b846aa1"
+  - title: "Building Scalable and Flexible Cluster Managers Using Declarative Programming"
+    doi: "https://www.usenix.org/conference/osdi20/presentation/suresh"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/vmware/declarative-cluster-management/"
+  - title: "Theseus: an Experiment in Operating System Structure and State Management"
+    doi: "https://www.usenix.org/conference/osdi20/presentation/boos"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/theseus-os/Theseus/tree/osdi20ae/osdi20ae"
+  - title: "A large scale analysis of hundreds of in-memory cache clusters at Twitter"
+    doi: "https://www.usenix.org/conference/osdi20/presentation/yang"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/Thesys-lab/InMemoryCachingWorkloadAnalysis"
+  - title: "Cobra: Making Transactional Key-Value Stores Verifiably Serializable"
+    doi: "https://www.usenix.org/conference/osdi20/presentation/tan"
+    badges: "Available,Reproduced"
+    repository_url: "https://github.com/DBCobra/CobraHome/tree/OSDI20-AE"
+  - title: "Generalized Sub-Query Fusion for Eliminating Redundant I/O from Big-Data Queries"
+    doi: "https://www.usenix.org/conference/osdi20/presentation/sarthi"
+    badges: "Functional,Reproduced"
+    repository_url: "https://resin.azurehdinsight.net/zeppelin/#/notebook/2FJC89KRJ"
+  - title: "Heterogeneity-Aware Cluster Scheduling Policies for Deep Learning Workloads"
+    doi: "https://www.usenix.org/conference/osdi20/presentation/narayanan-deepak"
+    badges: "Available,Functional"
+    repository_url: "https://github.com/stanford-futuredata/gavel/tree/osdi20"
+  - title: "Microsecond Consensus for Microsecond Applications"
+    doi: "https://www.usenix.org/conference/osdi20/presentation/aguilera"
+    badges: "Available,Functional"
+    repository_url: "https://github.com/osdi2020-no-152/dory"
+  - title: "Semeru: A Memory-Disaggregated Managed Runtime"
+    doi: "https://www.usenix.org/conference/osdi20/presentation/wang"
+    badges: "Available,Functional"
+    repository_url: "https://github.com/uclasystem/Semeru"
+  - title: "KungFu: Making Training in Distributed Machine Learning Adaptive"
+    doi: "https://www.usenix.org/conference/osdi20/presentation/mai"
+    badges: "Available,Functional"
+    repository_url: "https://github.com/lsds/KungFu/tree/ae-submissionV2"
+  - title: "Automated Reasoning and Detection of Specious Configuration in Large Systems with Symbolic Execution"
+    doi: "https://www.usenix.org/conference/osdi20/presentation/hu"
+    badges: "Available,Functional"
+    repository_url: "https://github.com/OrderLab/violet"
+  - title: "Aragog: Scalable Runtime Verification of Shardable Networked Systems"
+    doi: "https://www.usenix.org/conference/osdi20/presentation/yaseen"
+    badges: "Available,Functional"
+    repository_url: "https://github.com/NofelYaseen/MBVerifier"
+  - title: "CrossFS: A Cross-layered Direct-Access File System"
+    doi: "https://www.usenix.org/conference/osdi20/presentation/ren"
+    badges: "Available,Functional"
+    repository_url: "https://gitlab.com/yj_ren/aecross"
+  - title: "Assise: Performance and Availability via Client-local NVM in a Distributed File System"
+    doi: "https://www.usenix.org/conference/osdi20/presentation/anderson"
+    badges: "Available,Functional"
+    repository_url: "https://bitbucket.org/mlfs/assise-artifact"
+  - title: "LinnOS: Predictability on Unpredictable Flash Storage with a Light Neural Network"
+    doi: "https://www.usenix.org/conference/osdi20/presentation/hao"
+    badges: "Available"
+    repository_url: "https://www.chameleoncloud.org/experiment/share/15?s=409ab137f20e4cd38ae3dd4e0d4bfa7c"
+
 ---
-
-<style>
-table th:first-of-type {
-    width: 60%;
-    margin-top:10px;
-    margin-bottom:10px;
-}
-table th:nth-of-type(2) {
-    width: 20%;
-    margin-top:10px;
-    margin-bottom:10px;
-}
-table th:nth-of-type(3) {
-    width: 20%;
-    margin-top:10px;
-    margin-bottom:10px;
-}
-
-table td {
-    padding:0.25em;
-}
-
-span#aa {
-    background-color:#f15c24;
-    color:#FFFFFF;
-    font-weight: bold;
-    display: inline-block;
-    margin: 0px 0px 0px 0px;
-    width:100%;
-}
-
-span#af {
-    background-color:#1274bb;
-    color:#FFFFFF;
-    font-weight: bold;
-    display: inline-block;
-    margin: 0px 0px 0px 0px;
-    width:100%;
-}
-
-span#rr {
-    background-color:#6c4099;
-    color:#FFFFFF;
-    font-weight: bold;
-    display: inline-block;
-    margin: 0px 0px 0px 0px;
-    width:100%;
-}
-
-</style>
 
 **Submissions**: 49 (70% of accepted papers)
 
@@ -66,53 +219,55 @@ span#rr {
 * **"Testing Database Engines via Pivoted Query Synthesis"** by Manuel Rigger and Zhendong Su (ETH Zurich)
 * **"Serving DNNs like Clockwork: Performance Predictability from the Bottom Up"** <br> by Arpan Gujarati (MPI-SWS), Reza Karimi (Emory University), Safya Alzayat (MPI-SWS), Wei Hao (MPI-SWS), Antoine Kaufmann (MPI-SWS), Ymir Vigfusson (Emory University), and Jonathan Mace (MPI-SWS)
 
-| Paper title | Awarded Badges | Available at |
-|:-----------|:--------------:|:------------:|
-| [Testing Database Engines via Pivoted Query Synthesis](https://www.usenix.org/conference/osdi20/presentation/rigger) <br> **Distinguished Artifact Award** |  <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [DOI](http://doi.org/10.5281/zenodo.4005705) |
-| [Specification and verification in the field: Applying formal methods to BPF just-in-time compilers in the Linux kernel](https://www.usenix.org/conference/osdi20/presentation/nelson) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/uw-unsat/jitterbug/tree/osdi20-artifact) |
-| [RackSched: A Microsecond-Scale Scheduler for Rack-Scale Computers](https://www.usenix.org/conference/osdi20/presentation/zhu) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/netx-repo/RSCS) |
-| [Overload Control for µs-scale RPCs with Breakwater](https://www.usenix.org/conference/osdi20/presentation/cho) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/joshuafried/caladan-ae/tree/osdi20ae/breakwater) |
-| [Gauntlet: Finding Bugs in Compilers for Programmable Packet Processing](https://www.usenix.org/conference/osdi20/presentation/ruffy) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/p4gauntlet/gauntlet/tree/aec) |
-| [AGAMOTTO: How Persistent is your Persistent Memory Application?](https://www.usenix.org/conference/osdi20/presentation/neal) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/efeslab/agamotto/tree/artifact-eval-osdi20/artifact) |
-| [FIRM: An Intelligent Fine-grained Resource Management Framework for SLO-Oriented Microservices](https://www.usenix.org/conference/osdi20/presentation/qiu) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Gitlab](https://gitlab.engr.illinois.edu/DEPEND/firm) |
-| [SafetyPin: Encrypted Backups with Human-Memorable Secrets](https://www.usenix.org/conference/osdi20/presentation/dauterman-safetypin) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/edauterman/SafetyPin) |
-| [DORY: An Encrypted Search System with Distributed Trust](https://www.usenix.org/conference/osdi20/presentation/dauterman-dory) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/ucbrise/dory) |
-| [A Unified Architecture for Accelerating Distributed DNN Training in Heterogeneous GPU/CPU Clusters](https://www.usenix.org/conference/osdi20/presentation/jiang) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/bytedance/byteps/) |
-| [hXDP: Efficient Software Packet Processing on FPGA NICs](https://www.usenix.org/conference/osdi20/presentation/brunella) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/axbryd/hXDP-Artifacts/tree/camera-ready-v2.0) |
-| [Fault-tolerant and transactional stateful serverless workflows](https://www.usenix.org/conference/osdi20/presentation/zhang-haoran) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/eniac/Beldi) |
-| [From WiscKey to Bourbon: A Learned Index for Log-Structured Merge Trees](https://www.usenix.org/conference/osdi20/presentation/dai) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Bitbucket](https://bitbucket.org/daiyifandanny/learned-leveldb/src/master/) |
-| [AIFM: High-Performance, Application-Integrated Far Memory](https://www.usenix.org/conference/osdi20/presentation/ruan) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/zainryan/AIFM-AE) |
-| [Toward a Generic Fault Tolerance Technique for Partial Network Partitioning](https://www.usenix.org/conference/osdi20/presentation/alfatafta) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/UWASL/NIFTY) |
-| [Achieving 100Gbps Intrusion Prevention on a Single Server](https://www.usenix.org/conference/osdi20/presentation/zhao-zhipeng) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/cmu-snap/pigasus) |
-| [Serving DNNs like Clockwork: Performance Predictability from the Bottom Up](https://www.usenix.org/conference/osdi20/presentation/gujarati) <br> **Distinguished Artifact Award** | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Gitlab](https://gitlab.mpi-sws.org/cld/ml/clockwork-results/-/tree/osdi_2020_ae) [Gitlab](https://gitlab.mpi-sws.org/cld/ml/clockwork/-/tree/osdi_2020_ae) |
-| [Storage Systems are Distributed Systems (So Verify Them That Way!)](https://www.usenix.org/conference/osdi20/presentation/hance) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/secure-foundations/veribetrkv-osdi2020) |
-| [Pegasus: Tolerating Skewed Workloads in Distributed Storage with In-Network Coherence Directories](https://www.usenix.org/conference/osdi20/presentation/li-jialin) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/NUS-Systems-Lab/pegasus.git) |
-| [Byzantine Ordered Consensus without Byzantine Oligarchy](https://www.usenix.org/conference/osdi20/presentation/zhang-yunhao) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/yhzhang0128/osdi20-artifact-evaluation) |
-| [Rammer: Enabling Holistic Deep Learning Compiler Optimizations with rTasks](https://www.usenix.org/conference/osdi20/presentation/ma) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/microsoft/nnfusion/tree/osdi20_artifact/artifacts) |
-| [A Simpler and Faster NIC Driver Model for Network Functions](https://www.usenix.org/conference/osdi20/presentation/pirelli) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/dslab-epfl/tinynf) |
-| [Caladan: Mitigating Interference at Microsecond Timescales](https://www.usenix.org/conference/osdi20/presentation/fried) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/joshuafried/caladan-artifact) |
-| [Efficiently Mitigating Transient Execution Attacks using the Unmapped Speculation Contract](https://www.usenix.org/conference/osdi20/presentation/behrens) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/mit-pdos/ward) |
-| [PANIC: A High-Performance Programmable NIC for Multi-tenant Networks](https://www.usenix.org/conference/osdi20/presentation/lin) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Bitbucket](https://bitbucket.org/uw-madison-networking-research/panic_osdi20_artifact/src/master/) |
-| [Performance-Optimal Read-Only Transactions](https://www.usenix.org/conference/osdi20/presentation/lu) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/princeton-sns/Eiger-PORT) [Github](https://github.com/princeton-sns/Scylla-PORT.git) |
-| [Retiarii: A Deep Learning Exploratory-Training Framework](https://www.usenix.org/conference/osdi20/presentation/zhang-quanlu) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/microsoft/nni/tree/retiarii_artifact) |
-| [Fast RDMA-based Ordered Key-Value Store using Remote Learned Cache](https://www.usenix.org/conference/osdi20/presentation/wei) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/SJTU-IPADS/xstore/tree/legacy) |
-| [Determinizing Crash Behavior with a Verified Snapshot-Consistent Flash Translation Layer](https://www.usenix.org/conference/osdi20/presentation/chang) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/yunshengtw/scftl) [Docker](https://hub.docker.com/r/yunshengchang/scftl) |
-| [PACEMAKER: Avoiding HeART attacks in storage clusters with disk-adaptive redundancy](https://www.usenix.org/conference/osdi20/presentation/kadekodi) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/saurabhkadekodi/preact-osdi-2020-artifact) |
-| [Ansor: Generating High-Performance Tensor Programs for Deep Learning](https://www.usenix.org/conference/osdi20/presentation/zheng) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Bitbucket](https://bitbucket.org/lmzheng/ansor-artifact/src/master/) |
-| [Do OS abstractions make sense on FPGAs?](https://www.usenix.org/conference/osdi20/presentation/roscoe) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/fpgasystems/Coyote) |
-| [Orchard: Differentially Private Analytics at Scale](https://www.usenix.org/conference/osdi20/presentation/roth) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/edoroth/orchard) |
-| [A Tensor Compiler for Unified Machine Learning Prediction Serving](https://www.usenix.org/conference/osdi20/presentation/nakandala) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/microsoft/hummingbird/commit/dbebbb715e7050b47895082664adc27f8b846aa1) |
-| [Building Scalable and Flexible Cluster Managers Using Declarative Programming](https://www.usenix.org/conference/osdi20/presentation/suresh) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/vmware/declarative-cluster-management/) |
-| [Theseus: an Experiment in Operating System Structure and State Management](https://www.usenix.org/conference/osdi20/presentation/boos) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/theseus-os/Theseus/tree/osdi20ae/osdi20ae) |
-| [A large scale analysis of hundreds of in-memory cache clusters at Twitter](https://www.usenix.org/conference/osdi20/presentation/yang) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/Thesys-lab/InMemoryCachingWorkloadAnalysis) |
-| [Cobra: Making Transactional Key-Value Stores Verifiably Serializable](https://www.usenix.org/conference/osdi20/presentation/tan) | <span id="aa">AVAILABLE</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/DBCobra/CobraHome/tree/OSDI20-AE) |
-| [Generalized Sub-Query Fusion for Eliminating Redundant I/O from Big-Data Queries](https://www.usenix.org/conference/osdi20/presentation/sarthi) | <span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Zeppelin](https://resin.azurehdinsight.net/zeppelin/#/notebook/2FJC89KRJ) |
-| [Heterogeneity-Aware Cluster Scheduling Policies for Deep Learning Workloads](https://www.usenix.org/conference/osdi20/presentation/narayanan-deepak) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span> | [Github](https://github.com/stanford-futuredata/gavel/tree/osdi20) |
-| [Microsecond Consensus for Microsecond Applications](https://www.usenix.org/conference/osdi20/presentation/aguilera) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span> | [Github](https://github.com/osdi2020-no-152/dory) |
-| [Semeru: A Memory-Disaggregated Managed Runtime](https://www.usenix.org/conference/osdi20/presentation/wang) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span> | [Github](https://github.com/uclasystem/Semeru) |
-| [KungFu: Making Training in Distributed Machine Learning Adaptive](https://www.usenix.org/conference/osdi20/presentation/mai) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span> | [Github](https://github.com/lsds/KungFu/tree/ae-submissionV2) |
-| [Automated Reasoning and Detection of Specious Configuration in Large Systems with Symbolic Execution](https://www.usenix.org/conference/osdi20/presentation/hu) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span> | [Github](https://github.com/OrderLab/violet) |
-| [Aragog: Scalable Runtime Verification of Shardable Networked Systems](https://www.usenix.org/conference/osdi20/presentation/yaseen) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span> | [Github](https://github.com/NofelYaseen/MBVerifier) |
-| [CrossFS: A Cross-layered Direct-Access File System](https://www.usenix.org/conference/osdi20/presentation/ren) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span> | [Gitlab](https://gitlab.com/yj_ren/aecross) |
-| [Assise: Performance and Availability via Client-local NVM in a Distributed File System](https://www.usenix.org/conference/osdi20/presentation/anderson) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span> | [Bitbucket](https://bitbucket.org/mlfs/assise-artifact) |
-| [LinnOS: Predictability on Unpredictable Flash Storage with a Light Neural Network](https://www.usenix.org/conference/osdi20/presentation/hao) | <span id="aa">AVAILABLE</span> | [Chameleon](https://www.chameleoncloud.org/experiment/share/15?s=409ab137f20e4cd38ae3dd4e0d4bfa7c) |
+<table>
+  <thead>
+    <tr>
+      <th>Paper</th>
+      <th width="75px">Avail.</th>
+      <th width="75px">Funct.</th>
+      <th width="75px">Repro.</th>
+      <th>Available At</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% assign sorted_artifacts = page.artifacts | sort: "title" %}
+  {% for artifact in sorted_artifacts %}
+    <tr>
+      <td>
+        {% if artifact.doi %}
+            <a href="{{artifact.doi}}" target="_blank">{{artifact.title}}</a>
+        {% else %}
+            {{ artifact.title }}
+        {% endif %}
+        {% if artifact.award %}
+          <br><b>{{ artifact.award }}</b>
+        {% endif %}
+      </td>
+      <td width="75px">
+        {% if artifact.badges contains "Available" %}
+          <img src="{{ site.baseurl }}/images/{{ page.available_img }}" alt="{{ page.available_name }}">
+        {% endif %}
+      </td>
+      <td width="75px">
+        {% if artifact.badges contains "Functional" %}
+          <img src="{{ site.baseurl }}/images/{{ page.functional_img }}" alt="{{ page.functional_name }}">
+        {% endif %}
+      </td>
+      <td width="75px">
+        {% if artifact.badges contains "Reproduced" %}
+          <img src="{{ site.baseurl }}/images/{{ page.reproduced_img }}" alt="{{ page.reproduced_name }}">
+        {% endif %}
+      </td>
+      <td width="120px">
+        {% if artifact.artifact_url %}
+          <a href="{{artifact.artifact_url}}" target="_blank">Artifact</a><br>
+        {% endif %} {% if artifact.repository_url %}
+          <a href="{{artifact.repository_url}}" target="_blank">Repository</a><br>
+        {% endif %} {% if artifact.appendix_url %}
+          <a href="{{artifact.appendix_url}}" target="_blank">Appendix</a><br>
+        {% endif %}
+      </td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>

--- a/_conferences/osdi2021/results.md
+++ b/_conferences/osdi2021/results.md
@@ -1,57 +1,121 @@
 ---
 title: Results
 order: 40
+available_img: "usenix_available.svg"
+available_name: "Artifacts Available"
+functional_img: "usenix_functional.svg"
+functional_name: "Artifacts Evaluated - Functional"
+reproduced_img: "usenix_reproduced.svg"
+reproduced_name: "Results Reproduced"
+
+artifacts:
+  - title: "Nap: A Black-Box Approach to NUMA-Aware Persistent Memory Indexes"
+    doi: "https://www.usenix.org/conference/osdi21/presentation/wang-qing"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/thustorage/osdi21ae"
+  - title: "Oort: Efficient Federated Learning via Guided Participant Selection"
+    doi: "https://www.usenix.org/conference/osdi21/presentation/lai"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/SymbioticLab/Kuiper"
+  - title: "NrOS: Effective Replication and Sharing in an Operating System"
+    doi: "https://www.usenix.org/conference/osdi21/presentation/bhardwaj"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://nrkernel.systems/book/benchmarking/ArtifactEvaluation.html"
+  - title: "Optimizing Storage Performance with Calibrated Interrupts"
+    doi: "https://www.usenix.org/conference/osdi21/presentation/tai"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/amytai/cinterrupts-osdi"
+  - title: "The nanoPU: A Nanosecond Network Stack for Datacenters"
+    doi: "https://www.usenix.org/conference/osdi21/presentation/ibanez"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/l-nic/chipyard/tree/nanoPU-artifact-v1.0"
+  - title: "MAGE: Nearly Zero-Cost Virtual Memory for Secure Computation"
+    doi: "https://www.usenix.org/conference/osdi21/presentation/kumar"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/ucbrise/mage"
+  - title: "Polyjuice: High-Performance Transactions via Learned Concurrency Control"
+    doi: "https://www.usenix.org/conference/osdi21/presentation/wang-jiachen"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://ipads.se.sjtu.edu.cn/ae/README_polyjuice.html"
+  - title: "PET: Optimizing Tensor Programs with Partially Equivalent Transformations and Automated Corrections"
+    doi: "https://www.usenix.org/conference/osdi21/presentation/wang"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/whjthu/pet-osdi21-ae"
+  - title: "Scalable Memory Protection in the PENGLAI Enclave"
+    doi: "https://www.usenix.org/conference/osdi21/presentation/feng"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/Penglai-Enclave/Penglai-Enclave-TVM"
+  - title: "GNNAdvisor: An Adaptive and Efficient Runtime System for GNN Acceleration on GPUs"
+    doi: "https://www.usenix.org/conference/osdi21/presentation/wang-yuke"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/YukeWang96/OSDI21_AE.git"
+  - title: "Rearchitecting Linux Storage Stack for µs latency and High Throughput"
+    doi: "https://www.usenix.org/conference/osdi21/presentation/hwang"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/resource-disaggregation/blk-switch"
+  - title: "GoJournal: a verified, concurrent, crash-safe journaling system"
+    doi: "https://www.usenix.org/conference/osdi21/presentation/chajed"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/mit-pdos/goose-nfsd/"
+  - title: "DistInv: Data-Driven Automated Invariant Learning for Distributed Protocols"
+    doi: "https://www.usenix.org/conference/osdi21/presentation/yao"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://drive.google.com/file/d/1ogBU9KvZsvSRhXerY9Bv-MuiW9oOezBU/view?usp=sharing"
+  - title: "Pollux: Co-adaptive Cluster Scheduling for Goodput-Optimized Deep Learning"
+    doi: "https://www.usenix.org/conference/osdi21/presentation/qiao"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/aurickq/pollux-artifact"
+  - title: "Dorylus: Affordable, Scalable, and Accurate GNN Training with Distributed CPU Servers and Serverless Threads"
+    doi: "https://www.usenix.org/conference/osdi21/presentation/thorpe"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/uclasystem/dorylus"
+  - title: "Zeph: Cryptographic Enforcement of End-to-End Data Privacy"
+    doi: "https://www.usenix.org/conference/osdi21/presentation/burkhalter"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/pps-lab/zeph-artifact"
+  - title: "ZNS+: Advanced Zoned Namespace Interface for Supporting In-Storage Zone Compaction"
+    doi: "https://www.usenix.org/conference/osdi21/presentation/han"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "http://nyx.skku.ac.kr/?page_id=2808"
+  - title: "STORM: Refinement Types for Secure Web Applications"
+    doi: "https://www.usenix.org/conference/osdi21/presentation/lehmann"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/storm-framework/artifact"
+  - title: " Marius: Learning Massive Graph Embeddings on a Single Machine"
+    doi: "https://www.usenix.org/conference/osdi21/presentation/mohoney"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/marius-team/marius/tree/osdi2021"
+  - title: " CLP: Efficient and Scalable Search on Compressed Text Logs"
+    doi: "https://www.usenix.org/conference/osdi21/presentation/rodrigues"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "http://permalinks.yscope.com/clp-osdi21.tar.gz"
+  - title: " SANRAZOR: Reducing Redundant Sanitizer Checks in C/C++ Programs"
+    doi: "https://www.usenix.org/conference/osdi21/presentation/zhang"
+    badges: "Available,Functional"
+    artifact_url: "https://zenodo.org/record/4655221#.YGU8SEhKhhE"
+  - title: " Modernizing File System through In-Storage Indexing"
+    doi: "https://www.usenix.org/conference/osdi21/presentation/koo"
+    badges: "Available,Functional"
+    artifact_url: "https://zenodo.org/record/4659803"
+  - title: " Privacy Budget Scheduling"
+    doi: "https://www.usenix.org/conference/osdi21/presentation/luo"
+    badges: "Available,Functional"
+    repository_url: "https://github.com/columbia/PrivateKube/"
+  - title: " Retrofitting High Availability Mechanism to Tame Hybrid Transaction/Analytical Processing"
+    doi: "https://www.usenix.org/conference/osdi21/presentation/shen"
+    badges: "Available"
+    repository_url: "https://ipads.se.sjtu.edu.cn:1312/opensource/vegito"
+  - title: " DMon: Efficient Detection and Correction of Data Locality Problems using Selective Profiling"
+    doi: "https://www.usenix.org/conference/osdi21/presentation/khan"
+    badges: "Available"
+    repository_url: "https://github.com/efeslab/DMon-AE"
+  - title: " Horcrux: Automatic JavaScript Parallelism for Resource-Efficient Web Computation"
+    doi: "https://www.usenix.org/conference/osdi21/presentation/mardani"
+    badges: "Available"
+    repository_url: "https://github.com/ShaghayeghMrdn/horcrux-osdi21#horcrux"
+
 ---
 
-<style>
-table th:first-of-type {
-    width: 60%;
-    margin-top:10px;
-    margin-bottom:10px;
-}
-table th:nth-of-type(2) {
-    width: 20%;
-    margin-top:10px;
-    margin-bottom:10px;
-}
-table th:nth-of-type(3) {
-    width: 20%;
-    margin-top:10px;
-    margin-bottom:10px;
-}
-
-table td {
-    padding:0.25em;
-}
-
-span#aa {
-    background-color:#f15c24;
-    color:#FFFFFF;
-    font-weight: bold;
-    display: inline-block;
-    margin: 0px 0px 0px 0px;
-    width:100%;
-}
-
-span#af {
-    background-color:#1274bb;
-    color:#FFFFFF;
-    font-weight: bold;
-    display: inline-block;
-    margin: 0px 0px 0px 0px;
-    width:100%;
-}
-
-span#rr {
-    background-color:#6c4099;
-    color:#FFFFFF;
-    font-weight: bold;
-    display: inline-block;
-    margin: 0px 0px 0px 0px;
-    width:100%;
-}
-
-</style>
 
 **Submissions**: 26 (84% of accepted papers)
 
@@ -66,31 +130,48 @@ span#rr {
 * **"Oort: Efficient Federated Learning
 via Guided Participant Selection"** by Fan Lai, Xiangfeng Zhu, Harsha V. Madhyastha, and Mosharaf Chowdhury (University of Michigan)
 
-| Paper title | Awarded Badges | Available at |
-|:-----------:|:--------------:|:------------:|
-| [Nap: A Black-Box Approach to NUMA-Aware Persistent Memory Indexes](https://www.usenix.org/conference/osdi21/presentation/wang-qing) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/thustorage/osdi21ae) |
-| [Oort: Efficient Federated Learning via Guided Participant Selection](https://www.usenix.org/conference/osdi21/presentation/lai) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/SymbioticLab/Kuiper) |
-| [NrOS: Effective Replication and Sharing in an Operating System](https://www.usenix.org/conference/osdi21/presentation/bhardwaj) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://nrkernel.systems/book/benchmarking/ArtifactEvaluation.html) |
-| [Optimizing Storage Performance with Calibrated Interrupts](https://www.usenix.org/conference/osdi21/presentation/tai) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/amytai/cinterrupts-osdi) |
-| [The nanoPU: A Nanosecond Network Stack for Datacenters](https://www.usenix.org/conference/osdi21/presentation/ibanez) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/l-nic/chipyard/tree/nanoPU-artifact-v1.0) |
-| [MAGE: Nearly Zero-Cost Virtual Memory for Secure Computation](https://www.usenix.org/conference/osdi21/presentation/kumar) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/ucbrise/mage) |
-| [Polyjuice: High-Performance Transactions via Learned Concurrency Control](https://www.usenix.org/conference/osdi21/presentation/wang-jiachen) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://ipads.se.sjtu.edu.cn/ae/README_polyjuice.html) |
-| [PET: Optimizing Tensor Programs with Partially Equivalent Transformations and Automated Corrections](https://www.usenix.org/conference/osdi21/presentation/wang) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/whjthu/pet-osdi21-ae) |
-| [Scalable Memory Protection in the PENGLAI Enclave](https://www.usenix.org/conference/osdi21/presentation/feng) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/Penglai-Enclave/Penglai-Enclave-TVM) |
-| [GNNAdvisor: An Adaptive and Efficient Runtime System for GNN Acceleration on GPUs](https://www.usenix.org/conference/osdi21/presentation/wang-yuke) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/YukeWang96/OSDI21_AE.git) |
-| [Rearchitecting Linux Storage Stack for µs latency and High Throughput](https://www.usenix.org/conference/osdi21/presentation/hwang) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/resource-disaggregation/blk-switch) |
-| [GoJournal: a verified, concurrent, crash-safe journaling system](https://www.usenix.org/conference/osdi21/presentation/chajed) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/mit-pdos/goose-nfsd/) |
-| [DistInv: Data-Driven Automated Invariant Learning for Distributed Protocols](https://www.usenix.org/conference/osdi21/presentation/yao) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://drive.google.com/file/d/1ogBU9KvZsvSRhXerY9Bv-MuiW9oOezBU/view?usp=sharing) |
-| [Pollux: Co-adaptive Cluster Scheduling for Goodput-Optimized Deep Learning](https://www.usenix.org/conference/osdi21/presentation/qiao) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/aurickq/pollux-artifact) |
-| [Dorylus: Affordable, Scalable, and Accurate GNN Training with Distributed CPU Servers and Serverless Threads](https://www.usenix.org/conference/osdi21/presentation/thorpe) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/uclasystem/dorylus) |
-| [Zeph: Cryptographic Enforcement of End-to-End Data Privacy](https://www.usenix.org/conference/osdi21/presentation/burkhalter) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/pps-lab/zeph-artifact) |
-| [ZNS+: Advanced Zoned Namespace Interface for Supporting In-Storage Zone Compaction](https://www.usenix.org/conference/osdi21/presentation/han) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](http://nyx.skku.ac.kr/?page_id=2808) |
-| [STORM: Refinement Types for Secure Web Applications](https://www.usenix.org/conference/osdi21/presentation/lehmann) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/storm-framework/artifact) |
-| [ Marius: Learning Massive Graph Embeddings on a Single Machine](https://www.usenix.org/conference/osdi21/presentation/mohoney) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/marius-team/marius/tree/osdi2021) |
-| [ CLP: Efficient and Scalable Search on Compressed Text Logs](https://www.usenix.org/conference/osdi21/presentation/rodrigues) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](http://permalinks.yscope.com/clp-osdi21.tar.gz) |
-| [ SANRAZOR: Reducing Redundant Sanitizer Checks in C/C++ Programs](https://www.usenix.org/conference/osdi21/presentation/zhang) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span>| [DOI](https://zenodo.org/record/4655221#.YGU8SEhKhhE) |
-| [ Modernizing File System through In-Storage Indexing](https://www.usenix.org/conference/osdi21/presentation/koo) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span>| [DOI](https://zenodo.org/record/4659803) |
-| [ Privacy Budget Scheduling](https://www.usenix.org/conference/osdi21/presentation/luo) | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span> | [Github](https://github.com/columbia/PrivateKube/) |
-| [ Retrofitting High Availability Mechanism to Tame Hybrid Transaction/Analytical Processing](https://www.usenix.org/conference/osdi21/presentation/shen) | <span id="aa">AVAILABLE</span>| [Github](https://ipads.se.sjtu.edu.cn:1312/opensource/vegito) |
-| [ DMon: Efficient Detection and Correction of Data Locality Problems using Selective Profiling](https://www.usenix.org/conference/osdi21/presentation/khan) | <span id="aa">AVAILABLE</span>| [Github](https://github.com/efeslab/DMon-AE) |
-| [ Horcrux: Automatic JavaScript Parallelism for Resource-Efficient Web Computation](https://www.usenix.org/conference/osdi21/presentation/mardani) | <span id="aa">AVAILABLE</span>| [Github](https://github.com/ShaghayeghMrdn/horcrux-osdi21#horcrux) |
+<table>
+  <thead>
+    <tr>
+      <th>Paper</th>
+      <th width="75px">Avail.</th>
+      <th width="75px">Funct.</th>
+      <th width="75px">Repro.</th>
+      <th>Available At</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% assign sorted_artifacts = page.artifacts | sort: "title" %}
+  {% for artifact in sorted_artifacts %}
+    <tr>
+      <td>
+        {{ artifact.title }}
+      </td>
+      <td width="75px">
+        {% if artifact.badges contains "Available" %}
+          <img src="{{ site.baseurl }}/images/{{ page.available_img }}" alt="{{ page.available_name }}">
+        {% endif %}
+      </td>
+      <td width="75px">
+        {% if artifact.badges contains "Functional" %}
+          <img src="{{ site.baseurl }}/images/{{ page.functional_img }}" alt="{{ page.functional_name }}">
+        {% endif %}
+      </td>
+      <td width="75px">
+        {% if artifact.badges contains "Reproduced" %}
+          <img src="{{ site.baseurl }}/images/{{ page.reproduced_img }}" alt="{{ page.reproduced_name }}">
+        {% endif %}
+      </td>
+      <td width="120px">
+        {% if artifact.artifact_url %}
+          <a href="{{artifact.artifact_url}}" target="_blank">Artifact</a><br>
+        {% endif %} {% if artifact.repository_url %}
+          <a href="{{artifact.repository_url}}" target="_blank">Repository</a><br>
+        {% endif %} {% if artifact.appendix_url %}
+          <a href="{{artifact.appendix_url}}" target="_blank">Appendix</a><br>
+        {% endif %}
+      </td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>

--- a/_conferences/osdi2021/results.md
+++ b/_conferences/osdi2021/results.md
@@ -15,6 +15,7 @@ artifacts:
     repository_url: "https://github.com/thustorage/osdi21ae"
   - title: "Oort: Efficient Federated Learning via Guided Participant Selection"
     doi: "https://www.usenix.org/conference/osdi21/presentation/lai"
+    award: "Distinguished Artifact Award"
     badges: "Available,Functional,Reproduced"
     repository_url: "https://github.com/SymbioticLab/Kuiper"
   - title: "NrOS: Effective Replication and Sharing in an Operating System"
@@ -127,8 +128,7 @@ artifacts:
 
 **Distinguished Artifact Award**:
 
-* **"Oort: Efficient Federated Learning
-via Guided Participant Selection"** by Fan Lai, Xiangfeng Zhu, Harsha V. Madhyastha, and Mosharaf Chowdhury (University of Michigan)
+* **"Oort: Efficient Federated Learning via Guided Participant Selection"** by Fan Lai, Xiangfeng Zhu, Harsha V. Madhyastha, and Mosharaf Chowdhury (University of Michigan)
 
 <table>
   <thead>
@@ -145,7 +145,14 @@ via Guided Participant Selection"** by Fan Lai, Xiangfeng Zhu, Harsha V. Madhyas
   {% for artifact in sorted_artifacts %}
     <tr>
       <td>
-        {{ artifact.title }}
+        {% if artifact.doi %}
+            <a href="{{artifact.doi}}" target="_blank">{{artifact.title}}</a>
+        {% else %}
+            {{ artifact.title }}
+        {% endif %}
+        {% if artifact.award %}
+          <br><b>{{ artifact.award }}</b>
+        {% endif %}
       </td>
       <td width="75px">
         {% if artifact.badges contains "Available" %}

--- a/_conferences/osdi2022/results.md
+++ b/_conferences/osdi2022/results.md
@@ -1,58 +1,120 @@
 ---
 title: Results
 order: 40
+available_img: "usenix_available.svg"
+available_name: "Artifacts Available"
+functional_img: "usenix_functional.svg"
+functional_name: "Artifacts Evaluated - Functional"
+reproduced_img: "usenix_reproduced.svg"
+reproduced_name: "Results Reproduced"
+
+artifacts:
+  - title: "Demystifying and Checking Silent Semantic Violations in Large Distributed Systems"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/OrderLab/OathKeeper)
+  - title: "KSplit: Automating Device Driver Isolation"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/mars-research/ksplit-artifacts/)
+  - title: "ORION and the Three Rights: Sizing, Bundling, and Prewarming for Serverless DAGs"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/icanforce/Orion-OSDI22)
+  - title: "Time-Transcendent Debugging the OmniTable Way"
+    badges: "Available"
+    repository_url: "https://github.com/arquinn/SteamDrill)
+  - title: "Achieving μs-scale Preemption for Concurrent GPU-accelerated DNN Inferences"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/SJTU-IPADS/reef-artifacts)
+  - title: "BlackBox: Secure Containers on Untrusted Operating Systems using Arm Virtualization Hardware"
+    badges: "Available,Functional"
+    repository_url: "https://github.com/columbia/osdi22-paper162-ae)
+  - title: "Trinity: Desirable Mobile Emulation through Graphics Projection"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/TrinityEmulator/TrinityEmulator)
+  - title: "TriCache: A User-Transparent Block Cache Enabling High-Performance Out-of-Core Processing with In-Memory Programs"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/thu-pacman/TriCache)
+  - title: "FAERY: An FPGA-accelerated Embedding-based Retrieval System"
+    badges: "Functional"
+  - title: "Coffers: Capability-Based Isolation and Sharing for Microservices"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/lsds/intravisor)
+  - title: "zIO: Accelerating IO-Intensive Applications with Transparent Zero-Copy IO"
+    badges: "Available"
+    repository_url: "https://github.com/tstamler/zIO)
+  - title: "UPGRADVISOR: Early Adopting Dependency Updates Using Production Traces"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://figshare.com/s/69057b2bf22e0aa8a645)
+  - title: "SparTA: Deep-Learning Model Sparsity via Tensor-with-Sparsity-Attribute"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/microsoft/nni/tree/sparta_artifact)
+  - title: "Enabling Storage Harvesting for Improved Storage Utilization in Cloud Platforms"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/breidys2/BlockFlex)
+  - title: "Practically Correct, Just-in-Time Shell Script Parallelization"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/binpash/pash/blob/osdi22-ae/evaluation/osdi22-eval/)
+  - title: "Application-Informed Kernel Synchronization Primitives"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/rs3lab/SynCord)
+  - title: "Verifying the DaisyNFS concurrent and crash-safe file system with sequential reasoning"
+    badges: "Available"
+    repository_url: "https://github.com/mit-pdos/daisy-nfsd)
+  - title: "Operating System Support for Safe and Efficient Auxiliary Executions"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/OrderLab/orbit)
+  - title: "Efficient and Scalable Graph Pattern Mining on GPUs"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/chenxuhao/GraphMiner)
+  - title: "Odinfs: Scaling PM performance with Opportunistic Delegation"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/rs3lab/Odinfs)
+  - title: "Unity: Accelerating DNN Training Through Joint Optimization of Algebraic Transformations and Parallelization"
+    badges: "Available,Functional"
+    repository_url: "https://github.com/flexflow/FlexFlow/tree/osdi2022ae)
+  - title: "Metastable Failures in the Wild"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/lexiangh/Metastability)
+  - title: "Looking Beyond GPUs for DNN Scheduling on Multi-Tenant Clusters"
+    badges: "Available"
+    repository_url: "https://github.com/msr-fiddle/synergy)
+  - title: "Cancel Culture in Systems: An Empirical Study of Task Cancellation Patterns and Failures"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/whoisutsav/cancellation-study-osdi)
+  - title: "Roller: Fast and Efficient Tensor Compilation for Deep Learning"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/microsoft/nnfusion/tree/osdi22_artifact/artifacts)
+  - title: "MemLiner: Lining up Tracing and Application for a Far-Memory-Friendly Runtime"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/mahaoran1997/MemLiner)
+  - title: "Design and Verification of the Arm Confidential Compute Architecture"
+    badges: "Functional,Reproduced"
+    repository_url: "https://github.com/columbia/osdi-paper196-ae)
+  - title: "Shortstack: Scalable & Fault-tolerant Noise-Injection"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/pancake-security/shortstack-artifact)
+  - title: "Jawa: Web Archival in the Era of JavaScript"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/goelayu/Jawa)
+  - title: "Parax: Automating Inter- and Intra-Operator Parallelism for Distributed Deep Learning"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/alpa-projects/alpa/tree/osdi22_artifact/osdi22_artifact)
+  - title: "Fast, Automated Inference of Inductive Invariants for Verifying Distributed Protocols"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/VeriGu/Duo)
+  - title: "Immortal Threads: Multithreaded Event-driven Intermittent Computing on Ultra-Low-Power Microcontrollers"
+    badges: "Available,Functional"
+    repository_url: "https://github.com/tinysystems/ImmortalThreads)
+  - title: "XRP: In-Kernel Storage Functions with eBPF"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/xrp-project/XRP)
+  - title: "Embargo: Data Access Policy Enforcement for Web Applications"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://hub.docker.com/repository/docker/blockaid/ae)
+  - title: "Automatic Reliability Testing For Cluster Management Controllers"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/sieve-project/sieve/tree/osdi-ae)
+
 ---
-
-
-<style>
-table th:first-of-type {
-    width: 60%;
-    margin-top:10px;
-    margin-bottom:10px;
-}
-table th:nth-of-type(2) {
-    width: 20%;
-    margin-top:10px;
-    margin-bottom:10px;
-}
-table th:nth-of-type(3) {
-    width: 20%;
-    margin-top:10px;
-    margin-bottom:10px;
-}
-
-table td {
-    padding:0.25em;
-}
-
-span#aa {
-    background-color:#f15c24;
-    color:#FFFFFF;
-    font-weight: bold;
-    display: inline-block;
-    margin: 0px 0px 0px 0px;
-    width:100%;
-}
-
-span#af {
-    background-color:#1274bb;
-    color:#FFFFFF;
-    font-weight: bold;
-    display: inline-block;
-    margin: 0px 0px 0px 0px;
-    width:100%;
-}
-
-span#rr {
-    background-color:#6c4099;
-    color:#FFFFFF;
-    font-weight: bold;
-    display: inline-block;
-    margin: 0px 0px 0px 0px;
-    width:100%;
-}
-
-</style>
 
 **Submissions**: 35 (71% of accepted papers)
 
@@ -62,40 +124,49 @@ span#rr {
 * 31 Artifact Functional
 * 27 Results Reproduced
 
-| Paper title | Awarded Badges | Available at |
-|:-----------:|:--------------:|:------------:|
-| [Demystifying and Checking Silent Semantic Violations in Large Distributed Systems]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/OrderLab/OathKeeper) |
-| [KSplit: Automating Device Driver Isolation]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github1](https://github.com/mars-research/ksplit-artifacts/)<br>[Github2](https://github.com/mars-research/ksplit-cloudlab/) |
-| [ORION and the Three Rights: Sizing, Bundling, and Prewarming for Serverless DAGs]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/icanforce/Orion-OSDI22) |
-| [Time-Transcendent Debugging the OmniTable Way]() | <span id="aa">AVAILABLE</span> | [Github](https://github.com/arquinn/SteamDrill) |
-| [Achieving μs-scale Preemption for Concurrent GPU-accelerated DNN Inferences]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/SJTU-IPADS/reef-artifacts) |
-| [BlackBox: Secure Containers on Untrusted Operating Systems using Arm Virtualization Hardware]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br> | [Github](https://github.com/columbia/osdi22-paper162-ae) |
-| [Trinity: Desirable Mobile Emulation through Graphics Projection]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/TrinityEmulator/TrinityEmulator) |
-| [TriCache: A User-Transparent Block Cache Enabling High-Performance Out-of-Core Processing with In-Memory Programs]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/thu-pacman/TriCache) |
-| [FAERY: An FPGA-accelerated Embedding-based Retrieval System]() |<span id="af">FUNCTIONAL</span> | |
-| [Coffers: Capability-Based Isolation and Sharing for Microservices]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><span id="rr">REPRODUCED</span> | [Github](https://github.com/lsds/intravisor) |
-| [zIO: Accelerating IO-Intensive Applications with Transparent Zero-Copy IO]() | <span id="aa">AVAILABLE</span> | [Github](https://github.com/tstamler/zIO) |
-| [UPGRADVISOR: Early Adopting Dependency Updates Using Production Traces]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://figshare.com/s/69057b2bf22e0aa8a645) |
-| [SparTA: Deep-Learning Model Sparsity via Tensor-with-Sparsity-Attribute]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/microsoft/nni/tree/sparta_artifact) |
-| [Enabling Storage Harvesting for Improved Storage Utilization in Cloud Platforms]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/breidys2/BlockFlex) |
-| [Practically Correct, Just-in-Time Shell Script Parallelization]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/binpash/pash/blob/osdi22-ae/evaluation/osdi22-eval/) |
-| [Application-Informed Kernel Synchronization Primitives]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/rs3lab/SynCord) |
-| [Verifying the DaisyNFS concurrent and crash-safe file system with sequential reasoning]() | <span id="aa">AVAILABLE</span> | [Github](https://github.com/mit-pdos/daisy-nfsd) |
-| [Operating System Support for Safe and Efficient Auxiliary Executions]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/OrderLab/orbit) |
-| [Efficient and Scalable Graph Pattern Mining on GPUs]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/chenxuhao/GraphMiner) |
-| [Odinfs: Scaling PM performance with Opportunistic Delegation]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/rs3lab/Odinfs) |
-| [Unity: Accelerating DNN Training Through Joint Optimization of Algebraic Transformations and Parallelization]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span> | [Github](https://github.com/flexflow/FlexFlow/tree/osdi2022ae) |
-| [Metastable Failures in the Wild]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/lexiangh/Metastability) |
-| [Looking Beyond GPUs for DNN Scheduling on Multi-Tenant Clusters]() | <span id="aa">AVAILABLE</span><br> | [Github](https://github.com/msr-fiddle/synergy) |
-| [Cancel Culture in Systems: An Empirical Study of Task Cancellation Patterns and Failures]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/whoisutsav/cancellation-study-osdi) |
-| [Roller: Fast and Efficient Tensor Compilation for Deep Learning]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/microsoft/nnfusion/tree/osdi22_artifact/artifacts) |
-| [MemLiner: Lining up Tracing and Application for a Far-Memory-Friendly Runtime]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/mahaoran1997/MemLiner) |
-| [Design and Verification of the Arm Confidential Compute Architecture]() | <span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/columbia/osdi-paper196-ae) |
-| [Shortstack: Scalable & Fault-tolerant Noise-Injection]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/pancake-security/shortstack-artifact) |
-| [Jawa: Web Archival in the Era of JavaScript]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/goelayu/Jawa) |
-| [Parax: Automating Inter- and Intra-Operator Parallelism for Distributed Deep Learning]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/alpa-projects/alpa/tree/osdi22_artifact/osdi22_artifact) |
-| [Fast, Automated Inference of Inductive Invariants for Verifying Distributed Protocols]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/VeriGu/Duo) |
-| [Immortal Threads: Multithreaded Event-driven Intermittent Computing on Ultra-Low-Power Microcontrollers]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span> | [Github](https://github.com/tinysystems/ImmortalThreads) |
-| [XRP: In-Kernel Storage Functions with eBPF]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/xrp-project/XRP) |
-| [Embargo: Data Access Policy Enforcement for Web Applications]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Docker](https://hub.docker.com/repository/docker/blockaid/ae) |
-| [Automatic Reliability Testing For Cluster Management Controllers]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/sieve-project/sieve/tree/osdi-ae) |
+
+<table>
+  <thead>
+    <tr>
+      <th>Paper</th>
+      <th width="75px">Avail.</th>
+      <th width="75px">Funct.</th>
+      <th width="75px">Repro.</th>
+      <th>Available At</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% assign sorted_artifacts = page.artifacts | sort: "title" %}
+  {% for artifact in sorted_artifacts %}
+    <tr>
+      <td>
+        {{ artifact.title }}
+      </td>
+      <td width="75px">
+        {% if artifact.badges contains "Available" %}
+          <img src="{{ site.baseurl }}/images/{{ page.available_img }}" alt="{{ page.available_name }}">
+        {% endif %}
+      </td>
+      <td width="75px">
+        {% if artifact.badges contains "Functional" %}
+          <img src="{{ site.baseurl }}/images/{{ page.functional_img }}" alt="{{ page.functional_name }}">
+        {% endif %}
+      </td>
+      <td width="75px">
+        {% if artifact.badges contains "Reproduced" %}
+          <img src="{{ site.baseurl }}/images/{{ page.reproduced_img }}" alt="{{ page.reproduced_name }}">
+        {% endif %}
+      </td>
+      <td width="120px">
+        {% if artifact.artifact_url %}
+          <a href="{{artifact.artifact_url}}" target="_blank">Artifact</a><br>
+        {% endif %} {% if artifact.repository_url %}
+          <a href="{{artifact.repository_url}}" target="_blank">Repository</a><br>
+        {% endif %} {% if artifact.appendix_url %}
+          <a href="{{artifact.appendix_url}}" target="_blank">Appendix</a><br>
+        {% endif %}
+      </td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>

--- a/_conferences/osdi2022/results.md
+++ b/_conferences/osdi2022/results.md
@@ -11,108 +11,108 @@ reproduced_name: "Results Reproduced"
 artifacts:
   - title: "Demystifying and Checking Silent Semantic Violations in Large Distributed Systems"
     badges: "Available,Functional,Reproduced"
-    repository_url: "https://github.com/OrderLab/OathKeeper)
+    repository_url: "https://github.com/OrderLab/OathKeeper"
   - title: "KSplit: Automating Device Driver Isolation"
     badges: "Available,Functional,Reproduced"
-    repository_url: "https://github.com/mars-research/ksplit-artifacts/)
+    repository_url: "https://github.com/mars-research/ksplit-artifacts/"
   - title: "ORION and the Three Rights: Sizing, Bundling, and Prewarming for Serverless DAGs"
     badges: "Available,Functional,Reproduced"
-    repository_url: "https://github.com/icanforce/Orion-OSDI22)
+    repository_url: "https://github.com/icanforce/Orion-OSDI22"
   - title: "Time-Transcendent Debugging the OmniTable Way"
     badges: "Available"
-    repository_url: "https://github.com/arquinn/SteamDrill)
+    repository_url: "https://github.com/arquinn/SteamDrill"
   - title: "Achieving μs-scale Preemption for Concurrent GPU-accelerated DNN Inferences"
     badges: "Available,Functional,Reproduced"
-    repository_url: "https://github.com/SJTU-IPADS/reef-artifacts)
+    repository_url: "https://github.com/SJTU-IPADS/reef-artifacts"
   - title: "BlackBox: Secure Containers on Untrusted Operating Systems using Arm Virtualization Hardware"
     badges: "Available,Functional"
-    repository_url: "https://github.com/columbia/osdi22-paper162-ae)
+    repository_url: "https://github.com/columbia/osdi22-paper162-ae"
   - title: "Trinity: Desirable Mobile Emulation through Graphics Projection"
     badges: "Available,Functional,Reproduced"
-    repository_url: "https://github.com/TrinityEmulator/TrinityEmulator)
+    repository_url: "https://github.com/TrinityEmulator/TrinityEmulator"
   - title: "TriCache: A User-Transparent Block Cache Enabling High-Performance Out-of-Core Processing with In-Memory Programs"
     badges: "Available,Functional,Reproduced"
-    repository_url: "https://github.com/thu-pacman/TriCache)
+    repository_url: "https://github.com/thu-pacman/TriCache"
   - title: "FAERY: An FPGA-accelerated Embedding-based Retrieval System"
     badges: "Functional"
   - title: "Coffers: Capability-Based Isolation and Sharing for Microservices"
     badges: "Available,Functional,Reproduced"
-    repository_url: "https://github.com/lsds/intravisor)
+    repository_url: "https://github.com/lsds/intravisor"
   - title: "zIO: Accelerating IO-Intensive Applications with Transparent Zero-Copy IO"
     badges: "Available"
-    repository_url: "https://github.com/tstamler/zIO)
+    repository_url: "https://github.com/tstamler/zIO"
   - title: "UPGRADVISOR: Early Adopting Dependency Updates Using Production Traces"
     badges: "Available,Functional,Reproduced"
-    repository_url: "https://figshare.com/s/69057b2bf22e0aa8a645)
+    repository_url: "https://figshare.com/s/69057b2bf22e0aa8a645"
   - title: "SparTA: Deep-Learning Model Sparsity via Tensor-with-Sparsity-Attribute"
     badges: "Available,Functional,Reproduced"
-    repository_url: "https://github.com/microsoft/nni/tree/sparta_artifact)
+    repository_url: "https://github.com/microsoft/nni/tree/sparta_artifact"
   - title: "Enabling Storage Harvesting for Improved Storage Utilization in Cloud Platforms"
     badges: "Available,Functional,Reproduced"
-    repository_url: "https://github.com/breidys2/BlockFlex)
+    repository_url: "https://github.com/breidys2/BlockFlex"
   - title: "Practically Correct, Just-in-Time Shell Script Parallelization"
     badges: "Available,Functional,Reproduced"
-    repository_url: "https://github.com/binpash/pash/blob/osdi22-ae/evaluation/osdi22-eval/)
+    repository_url: "https://github.com/binpash/pash/blob/osdi22-ae/evaluation/osdi22-eval/"
   - title: "Application-Informed Kernel Synchronization Primitives"
     badges: "Available,Functional,Reproduced"
-    repository_url: "https://github.com/rs3lab/SynCord)
+    repository_url: "https://github.com/rs3lab/SynCord"
   - title: "Verifying the DaisyNFS concurrent and crash-safe file system with sequential reasoning"
     badges: "Available"
-    repository_url: "https://github.com/mit-pdos/daisy-nfsd)
+    repository_url: "https://github.com/mit-pdos/daisy-nfsd"
   - title: "Operating System Support for Safe and Efficient Auxiliary Executions"
     badges: "Available,Functional,Reproduced"
-    repository_url: "https://github.com/OrderLab/orbit)
+    repository_url: "https://github.com/OrderLab/orbit"
   - title: "Efficient and Scalable Graph Pattern Mining on GPUs"
     badges: "Available,Functional,Reproduced"
-    repository_url: "https://github.com/chenxuhao/GraphMiner)
+    repository_url: "https://github.com/chenxuhao/GraphMiner"
   - title: "Odinfs: Scaling PM performance with Opportunistic Delegation"
     badges: "Available,Functional,Reproduced"
-    repository_url: "https://github.com/rs3lab/Odinfs)
+    repository_url: "https://github.com/rs3lab/Odinfs"
   - title: "Unity: Accelerating DNN Training Through Joint Optimization of Algebraic Transformations and Parallelization"
     badges: "Available,Functional"
-    repository_url: "https://github.com/flexflow/FlexFlow/tree/osdi2022ae)
+    repository_url: "https://github.com/flexflow/FlexFlow/tree/osdi2022ae"
   - title: "Metastable Failures in the Wild"
     badges: "Available,Functional,Reproduced"
-    repository_url: "https://github.com/lexiangh/Metastability)
+    repository_url: "https://github.com/lexiangh/Metastability"
   - title: "Looking Beyond GPUs for DNN Scheduling on Multi-Tenant Clusters"
     badges: "Available"
-    repository_url: "https://github.com/msr-fiddle/synergy)
+    repository_url: "https://github.com/msr-fiddle/synergy"
   - title: "Cancel Culture in Systems: An Empirical Study of Task Cancellation Patterns and Failures"
     badges: "Available,Functional,Reproduced"
-    repository_url: "https://github.com/whoisutsav/cancellation-study-osdi)
+    repository_url: "https://github.com/whoisutsav/cancellation-study-osdi"
   - title: "Roller: Fast and Efficient Tensor Compilation for Deep Learning"
     badges: "Available,Functional,Reproduced"
-    repository_url: "https://github.com/microsoft/nnfusion/tree/osdi22_artifact/artifacts)
+    repository_url: "https://github.com/microsoft/nnfusion/tree/osdi22_artifact/artifacts"
   - title: "MemLiner: Lining up Tracing and Application for a Far-Memory-Friendly Runtime"
     badges: "Available,Functional,Reproduced"
-    repository_url: "https://github.com/mahaoran1997/MemLiner)
+    repository_url: "https://github.com/mahaoran1997/MemLiner"
   - title: "Design and Verification of the Arm Confidential Compute Architecture"
     badges: "Functional,Reproduced"
-    repository_url: "https://github.com/columbia/osdi-paper196-ae)
+    repository_url: "https://github.com/columbia/osdi-paper196-ae"
   - title: "Shortstack: Scalable & Fault-tolerant Noise-Injection"
     badges: "Available,Functional,Reproduced"
-    repository_url: "https://github.com/pancake-security/shortstack-artifact)
+    repository_url: "https://github.com/pancake-security/shortstack-artifact"
   - title: "Jawa: Web Archival in the Era of JavaScript"
     badges: "Available,Functional,Reproduced"
-    repository_url: "https://github.com/goelayu/Jawa)
+    repository_url: "https://github.com/goelayu/Jawa"
   - title: "Parax: Automating Inter- and Intra-Operator Parallelism for Distributed Deep Learning"
     badges: "Available,Functional,Reproduced"
-    repository_url: "https://github.com/alpa-projects/alpa/tree/osdi22_artifact/osdi22_artifact)
+    repository_url: "https://github.com/alpa-projects/alpa/tree/osdi22_artifact/osdi22_artifact"
   - title: "Fast, Automated Inference of Inductive Invariants for Verifying Distributed Protocols"
     badges: "Available,Functional,Reproduced"
-    repository_url: "https://github.com/VeriGu/Duo)
+    repository_url: "https://github.com/VeriGu/Duo"
   - title: "Immortal Threads: Multithreaded Event-driven Intermittent Computing on Ultra-Low-Power Microcontrollers"
     badges: "Available,Functional"
-    repository_url: "https://github.com/tinysystems/ImmortalThreads)
+    repository_url: "https://github.com/tinysystems/ImmortalThreads"
   - title: "XRP: In-Kernel Storage Functions with eBPF"
     badges: "Available,Functional,Reproduced"
-    repository_url: "https://github.com/xrp-project/XRP)
+    repository_url: "https://github.com/xrp-project/XRP"
   - title: "Embargo: Data Access Policy Enforcement for Web Applications"
     badges: "Available,Functional,Reproduced"
-    repository_url: "https://hub.docker.com/repository/docker/blockaid/ae)
+    repository_url: "https://hub.docker.com/repository/docker/blockaid/ae"
   - title: "Automatic Reliability Testing For Cluster Management Controllers"
     badges: "Available,Functional,Reproduced"
-    repository_url: "https://github.com/sieve-project/sieve/tree/osdi-ae)
+    repository_url: "https://github.com/sieve-project/sieve/tree/osdi-ae"
 
 ---
 
@@ -140,7 +140,14 @@ artifacts:
   {% for artifact in sorted_artifacts %}
     <tr>
       <td>
-        {{ artifact.title }}
+        {% if artifact.doi %}
+            <a href="{{artifact.doi}}" target="_blank">{{artifact.title}}</a>
+        {% else %}
+            {{ artifact.title }}
+        {% endif %}
+        {% if artifact.award %}
+          <br><b>{{ artifact.award }}</b>
+        {% endif %}
       </td>
       <td width="75px">
         {% if artifact.badges contains "Available" %}

--- a/_conferences/osdi2023/results.md
+++ b/_conferences/osdi2023/results.md
@@ -1,58 +1,111 @@
 ---
 title: Results
 order: 40
+available_img: "usenix_available.svg"
+available_name: "Artifacts Available"
+functional_img: "usenix_functional.svg"
+functional_name: "Artifacts Evaluated - Functional"
+reproduced_img: "usenix_reproduced.svg"
+reproduced_name: "Results Reproduced"
+
+artifacts:
+  - title: "Take Out the TraChe: Maximizing (Tra)nsactional Ca(che) Hit"
+    badges: "Available"
+    repository_url: "https://github.com/audreyccheng/detox"
+  - title: "Core slicing: closing the gap between leaky confidential VMs and bare-metal cloud"
+    badges: "Available,Functional"
+    repository_url: "https://github.com/MSRSSP/slice-docker-env"
+  - title: "Detecting Transactional Bugs in Database Engines via Graph-Based Oracle Construction"
+    badges: "Available,Functional"
+    repository_url: "https://github.com/JZuming/TxCheck"
+    artifact_url: "https://zenodo.org/record/7859034#.ZEbk2s5By4Q"
+  - title: "EinNet: Optimizing Tensor Programs with Derivation-Based Transformations"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/zhengly123/OSDI23-EinNet-AE"
+  - title: "LVMT: An Efficient Authenticated Storage for Blockchain"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/ChenxingLi/asb-plotter"
+  - title: "Sharding the State Machine: Automated Modular Reasoning for Complex Concurrent Systems"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/secure-foundations/ironsync-osdi2023"
+  - title: "Ensō: A Streaming Interface for NIC-Application Communication"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/crossroadsfpga/enso"
+  - title: "BWoS: Formally Verified Block-based Work Stealing for Parallel Processing"
+    badges: "Functional,Reproduced"
+  - title: "Cilantro: A Framework for Performance-Aware Resource Allocation for General Objectives via Online Feedback"
+    badges: "Available,Functional"
+    repository_url: "https://github.com/romilbhardwaj/cilantro"
+  - title: "Security and Performance in the Delegated User-level Virtualization"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/IPADS-DuVisor/ae-guide"
+  - title: "Welder: Scheduling Deep Learning Memory Access via Tile-graph"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/nox-410/Welder_artifacts"
+  - title: "Accelerating Graph Neural Networks with Fine-grained intra-kernel Communication-Computation Pipelining on Multi-GPU Platforms"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/YukeWang96/MGG-OSDI23-AE.git"
+  - title: "Honeycomb: An Secure, Efficient GPU Execution Environment with Minimal TCB"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/Jiacheng/honeycomb-osdi23-ae"
+  - title: "Accountable authentication with privacy protection: The Larch system for universal login"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/edauterman/larch"
+  - title: "Hydro: Surrogate-Based Hyperparameter Tuning Service in the Datacenter"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/S-Lab-System-Group/Hydro"
+  - title: "ORC: Increasing Cloud Memory Density via Object Reuse with Capabilities"
+    badges: "Available,Functional"
+    repository_url: "https://github.com/lsds/intravisor"
+  - title: "Effectively Scheduling Computational Graphs of Deep Neural Networks toward Their Domain-Specific Accelerators"
+    badges: "Functional,Reproduced"
+    artifact_url: "https://doi.org/10.5281/zenodo.7859181"
+  - title: "Grinder: Analysis and Optimization for Dynamic Control Flow in Deep Learning"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/microsoft/nnfusion/tree/cocktailer_artifact"
+    artifact_url: "https://doi.org/10.5281/zenodo.7856472"
+  - title: "Encrypted Databases Made Secure Yet Maintainable"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/zhaoxuyang13/hedb"
+  - title: "ExoFlow: A Universal Workflow System for Exactly-Once DAGs"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/suquark/ExoFlow"
+  - title: "Beta: Statistical Multiplexing with Model Parallelism for Deep Learning Serving"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/alpa-projects/mms/tree/main/osdi23_artifact"
+  - title: "AutoV: Scaling Machine-Checkable Verification for Large System Software"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/columbia/osdi23-paper114-ae"
+  - title: "RON: One-Way Circular Shortest Routing to Achieve Efficient and Bounded-waiting Spinlocks"
+    badges: "Functional,Reproduced"
+  - title: "Relational Debugging --- Pinpointing Root Causes of Performance Problems"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/jrenx/Perspect/settings"
+  - title: "VBase: Unifying Online Vector Similarity Search and Relational Queries via Relaxed Monotonicity"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/Catoverflow/VBASE-artifacts"
+  - title: "Optimizing Dynamic Neural Networks with Brainstorm"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/Raphael-Hao/brainstorm/tree/osdi2023ae"
+  - title: "Userspace Bypass: Accelerating Syscall-intensive Applications"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/glarer/UserspaceBypass"
+  - title: "Ship your Critical Section Not Your Data: Enabling Transparent Delegation with TCLocks"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/rs3lab/TCLocks"
+  - title: "SMART: A High-Performance Adaptive Radix Tree for Disaggregated Memory"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/dmemsys/SMART"
+  - title: "Pelton: Privacy-Compliant Storage For Web Applications By Construction"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/brownsys/K9db/"
+  - title: "SEPH: Scalable, Efficient, and Predictable Hashing on Persistent Memory"
+    badges: "Available,Functional,Reproduced"
+  - title: "Nimble: Rollback Protection for Confidential Cloud Services"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/MSRSSP/Nimble"
+
 ---
-
-
-<style>
-table th:first-of-type {
-    width: 60%;
-    margin-top:10px;
-    margin-bottom:10px;
-}
-table th:nth-of-type(2) {
-    width: 20%;
-    margin-top:10px;
-    margin-bottom:10px;
-}
-table th:nth-of-type(3) {
-    width: 20%;
-    margin-top:10px;
-    margin-bottom:10px;
-}
-
-table td {
-    padding:0.25em;
-}
-
-span#aa {
-    background-color:#f15c24;
-    color:#FFFFFF;
-    font-weight: bold;
-    display: inline-block;
-    margin: 0px 0px 0px 0px;
-    width:100%;
-}
-
-span#af {
-    background-color:#1274bb;
-    color:#FFFFFF;
-    font-weight: bold;
-    display: inline-block;
-    margin: 0px 0px 0px 0px;
-    width:100%;
-}
-
-span#rr {
-    background-color:#6c4099;
-    color:#FFFFFF;
-    font-weight: bold;
-    display: inline-block;
-    margin: 0px 0px 0px 0px;
-    width:100%;
-}
-
-</style>
 
 **Submissions**: 32 (64% of accepted papers)
 
@@ -62,37 +115,49 @@ span#rr {
 * 31 Artifact Functional
 * 25 Results Reproduced
 
-| Paper title | Awarded Badges | Available at |
-|:-----------:|:--------------:|:------------:|
-| [Take Out the TraChe: Maximizing (Tra)nsactional Ca(che) Hit]() | <span id="aa">AVAILABLE</span> | [Github](https://github.com/audreyccheng/detox) |
-| [Core slicing: closing the gap between leaky confidential VMs and bare-metal cloud]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span> | [Github](https://github.com/MSRSSP/slice-docker-env) |
-| [Detecting Transactional Bugs in Database Engines via Graph-Based Oracle Construction]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span> | [Github](https://github.com/JZuming/TxCheck) <br> [Zenodo](https://zenodo.org/record/7859034#.ZEbk2s5By4Q) |
-| [EinNet: Optimizing Tensor Programs with Derivation-Based Transformations]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/zhengly123/OSDI23-EinNet-AE) |
-| [LVMT: An Efficient Authenticated Storage for Blockchain]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/ChenxingLi/asb-plotter) |
-| [Sharding the State Machine: Automated Modular Reasoning for Complex Concurrent Systems]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/secure-foundations/ironsync-osdi2023) |
-| [Ensō: A Streaming Interface for NIC-Application Communication]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Ensō Repository](https://github.com/crossroadsfpga/enso) <br> [Eval](https://github.com/crossroadsfpga/enso_eval) <br> [Docs](https://crossroadsfpga.github.io/enso/) |
-| [BWoS: Formally Verified Block-based Work Stealing for Parallel Processing]() | <span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | |
-| [Cilantro: A Framework for Performance-Aware Resource Allocation for General Objectives via Online Feedback]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span> | [Github](https://github.com/romilbhardwaj/cilantro) |
-| [Security and Performance in the Delegated User-level Virtualization]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/IPADS-DuVisor/ae-guide) |
-| [Welder: Scheduling Deep Learning Memory Access via Tile-graph]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/nox-410/Welder_artifacts) |
-| [Accelerating Graph Neural Networks with Fine-grained intra-kernel Communication-Computation Pipelining on Multi-GPU Platforms]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/YukeWang96/MGG-OSDI23-AE.git) |
-| [Honeycomb: An Secure, Efficient GPU Execution Environment with Minimal TCB]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/Jiacheng/honeycomb-osdi23-ae) |
-| [Accountable authentication with privacy protection: The Larch system for universal login]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/edauterman/larch) |
-| [Hydro: Surrogate-Based Hyperparameter Tuning Service in the Datacenter]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/S-Lab-System-Group/Hydro) |
-| [ORC: Increasing Cloud Memory Density via Object Reuse with Capabilities]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span> | [Github](https://github.com/lsds/intravisor) |
-| [Effectively Scheduling Computational Graphs of Deep Neural Networks toward Their Domain-Specific Accelerators]() | <span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Zenodo](https://doi.org/10.5281/zenodo.7859181) |
-| [Grinder: Analysis and Optimization for Dynamic Control Flow in Deep Learning]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/microsoft/nnfusion/tree/cocktailer_artifact) <br> [Zenodo](https://doi.org/10.5281/zenodo.7856472) |
-| [Encrypted Databases Made Secure Yet Maintainable]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/zhaoxuyang13/hedb) |
-| [ExoFlow: A Universal Workflow System for Exactly-Once DAGs]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/suquark/ExoFlow) |
-| [Beta: Statistical Multiplexing with Model Parallelism for Deep Learning Serving]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/alpa-projects/mms/tree/main/osdi23_artifact) |
-| [AutoV: Scaling Machine-Checkable Verification for Large System Software]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/columbia/osdi23-paper114-ae) |
-| [RON: One-Way Circular Shortest Routing to Achieve Efficient and Bounded-waiting Spinlocks]() | <span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | |
-| [Relational Debugging --- Pinpointing Root Causes of Performance Problems]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/jrenx/Perspect/settings) |
-| [VBase: Unifying Online Vector Similarity Search and Relational Queries via Relaxed Monotonicity]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/Catoverflow/VBASE-artifacts) |
-| [Optimizing Dynamic Neural Networks with Brainstorm]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/Raphael-Hao/brainstorm/tree/osdi2023ae) |
-| [Userspace Bypass: Accelerating Syscall-intensive Applications]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/glarer/UserspaceBypass) |
-| [Ship your Critical Section Not Your Data: Enabling Transparent Delegation with TCLocks]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/rs3lab/TCLocks) |
-| [SMART: A High-Performance Adaptive Radix Tree for Disaggregated Memory]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/dmemsys/SMART) |
-| [Pelton: Privacy-Compliant Storage For Web Applications By Construction]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/brownsys/K9db/) |
-| [SEPH: Scalable, Efficient, and Predictable Hashing on Persistent Memory]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | |
-| [Nimble: Rollback Protection for Confidential Cloud Services]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/MSRSSP/Nimble) |
+
+<table>
+  <thead>
+    <tr>
+      <th>Paper</th>
+      <th width="75px">Avail.</th>
+      <th width="75px">Funct.</th>
+      <th width="75px">Repro.</th>
+      <th>Available At</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% assign sorted_artifacts = page.artifacts | sort: "title" %}
+  {% for artifact in sorted_artifacts %}
+    <tr>
+      <td>
+        {{ artifact.title }}
+      </td>
+      <td width="75px">
+        {% if artifact.badges contains "Available" %}
+          <img src="{{ site.baseurl }}/images/{{ page.available_img }}" alt="{{ page.available_name }}">
+        {% endif %}
+      </td>
+      <td width="75px">
+        {% if artifact.badges contains "Functional" %}
+          <img src="{{ site.baseurl }}/images/{{ page.functional_img }}" alt="{{ page.functional_name }}">
+        {% endif %}
+      </td>
+      <td width="75px">
+        {% if artifact.badges contains "Reproduced" %}
+          <img src="{{ site.baseurl }}/images/{{ page.reproduced_img }}" alt="{{ page.reproduced_name }}">
+        {% endif %}
+      </td>
+      <td width="120px">
+        {% if artifact.artifact_url %}
+          <a href="{{artifact.artifact_url}}" target="_blank">Artifact</a><br>
+        {% endif %} {% if artifact.repository_url %}
+          <a href="{{artifact.repository_url}}" target="_blank">Repository</a><br>
+        {% endif %} {% if artifact.appendix_url %}
+          <a href="{{artifact.appendix_url}}" target="_blank">Appendix</a><br>
+        {% endif %}
+      </td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>

--- a/_conferences/osdi2023/results.md
+++ b/_conferences/osdi2023/results.md
@@ -131,7 +131,14 @@ artifacts:
   {% for artifact in sorted_artifacts %}
     <tr>
       <td>
-        {{ artifact.title }}
+        {% if artifact.doi %}
+            <a href="{{artifact.doi}}" target="_blank">{{artifact.title}}</a>
+        {% else %}
+            {{ artifact.title }}
+        {% endif %}
+        {% if artifact.award %}
+          <br><b>{{ artifact.award }}</b>
+        {% endif %}
       </td>
       <td width="75px">
         {% if artifact.badges contains "Available" %}

--- a/_conferences/osdi2024/result.md
+++ b/_conferences/osdi2024/result.md
@@ -176,6 +176,9 @@ artifacts:
         {% else %}
             {{ artifact.title }}
         {% endif %}
+        {% if artifact.award %}
+          <br><b>{{ artifact.award }}</b>
+        {% endif %}
       </td>
       <td width="75px">
         {% if artifact.badges contains "Available" %}

--- a/_conferences/osdi2024/result.md
+++ b/_conferences/osdi2024/result.md
@@ -171,7 +171,11 @@ artifacts:
   {% for artifact in sorted_artifacts %}
     <tr>
       <td>
-        {{ artifact.title }}
+        {% if artifact.doi %}
+            <a href="{{artifact.doi}}" target="_blank">{{artifact.title}}</a>
+        {% else %}
+            {{ artifact.title }}
+        {% endif %}
       </td>
       <td width="75px">
         {% if artifact.badges contains "Available" %}

--- a/_conferences/osdi2024/result.md
+++ b/_conferences/osdi2024/result.md
@@ -3,9 +3,9 @@ title: Results
 order: 40
 available_img: "usenix_available.svg"
 available_name: "Artifacts Available"
-functional_img: "usenix-functional.svg"
+functional_img: "usenix_functional.svg"
 functional_name: "Artifacts Evaluated - Functional"
-reproduced_img: "usenix-reproduced.svg"
+reproduced_img: "usenix_reproduced.svg"
 reproduced_name: "Results Reproduced"
 
 artifacts:

--- a/_conferences/osdi2024/result.md
+++ b/_conferences/osdi2024/result.md
@@ -1,58 +1,152 @@
 ---
 title: Results
 order: 40
+available_img: "usenix_available.svg"
+available_name: "Artifacts Available"
+functional_img: "usenix-functional.svg"
+functional_name: "Artifacts Evaluated - Functional"
+reproduced_img: "usenix-reproduced.svg"
+reproduced_name: "Results Reproduced"
+
+artifacts:
+
+  - title: "Data-flow Availability: Achieving Timing Assurance on Autonomous Systems"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/WUSTL-CSPL/Shore-Userspace"
+
+  - title: "Taming Throughput-Latency Tradeoff in LLM Inference with Sarathi-Serve"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://anonymous.4open.science/r/sarathi-serve-osdi-artifact-5EB8/"
+
+  - title: "Detecting Logic Bugs in Database Engines via Equivalent Expression Transformation"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/JZuming/EET"
+
+  - title: "Caravan: Practical Online Learning of In-Network ML Models with Labeling Agents"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/Per-Packet-AI/Caravan-Artifact-OSDI24"
+
+  - title: "Automatic and Efficient Customization of Neural Networks for ML Applications"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/UChi-JCL/chameleonAPI"
+
+  - title: "Fairness in Serving Large Language Models"
+    badges: "Available,Functional"
+    repository_url: "https://github.com/Ying1123/VTC-artifact"
+
+  - title: "Anvil: Verifying Liveness of Cluster Management Controllers"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/vmware-research/verifiable-controllers"
+
+  - title: "Managing Memory Tiers with CXL in Virtualized Environments"
+    badges: "Available"
+    repository_url: "https://bitbucket.org/yuhong_zhong/memstrata/src/master/"
+
+  - title: "Sabre: Improving Memory Prefetching in Serverless MicroVMs with Near-Memory Hardware-Accelerated Compression"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/barabanshek/sabre"
+
+  - title: "IronSpec: Increasing the Reliability of Formal Specifications"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/GLaDOS-Michigan/IronSpec"
+
+  - title: "VeriSMo: A Verified Security Module for Confidential VMs"
+    badges: "Available,Functional"
+    repository_url: "https://github.com/microsoft/verismo"
+
+  - title: "Inductive Invariants That Spark Joy: Using Invariant Taxonomies to Streamline Distributed Systems Proofs"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/GLaDOS-Michigan/Kondo-Artifact-OSDI24"
+
+  - title: "Parrot: Efficient Serving of LLM-based Applications with Semantic Variable"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/microsoft/ParrotServe/tree/artifact"
+
+  - title: "Anon: an FPGA-Based Collective Engine for Distributed Applications"
+    badges: "Available"
+    repository_url: "https://github.com/Xilinx/ACCL/tree/dev"
+
+  - title: "DSig: Breaking the Barrier of Signatures in Data Centers"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/LPD-EPFL/dsig-artifacts"
+
+  - title: "𝜇Slope: High Compression and Fast Search on Semi-Structured Logs"
+    badges: "Available,Functional,Reproduced"
+    artifact_url: "https://zenodo.org/records/11069592"
+
+  - title: "DRust: Language-Guided Distributed Shared Memory with Fine Granularity, Full Transparency, and Ultra Efficiency"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/uclasystem/DRust"
+
+  - title: "Beaver: Practical Partial Snapshots for Distributed Cloud Services"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/eniac/Beaver"
+
+  - title: "Llumnix: Dynamic Scheduling for Large Language Model Serving"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/alibaba/llm-scheduling-artifact"
+
+  - title: "dLoRA: Dynamically Orchestrating Requests and Adapters for LoRA LLM Serving"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/LLMServe/dLoRA-artifact"
+
+  - title: "Performance Interfaces for Hardware Accelerators"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/dslab-epfl/lpn"
+
+  - title: "What will it take for Johnny to know when his Cloud job will finish? Towards providing reliable job completion time predictions using PCS"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/abdullahfsm/PCS/tree/osdi2024-artifact"
+
+  - title: "Chop Chop: Byzantine Atomic Broadcast to the Network Limit"
+    badges: "Available,Functional"
+    repository_url: "https://github.com/Distributed-EPFL/chop-chop-osdi24?tab=readme-ov-file"
+
+  - title: "Secret Key Recovery in a Global-Scale End-to-End Encryption System"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/vivi/SecureValueRecovery2/tree/artifact/paper_experiments#readme"
+
+  - title: "SquirrelFS: using the Rust compiler to check file-system crash consistency"
+    badges: "Available,Functional"
+    repository_url: "https://github.com/hayley-leblanc/squirrelfs"
+
+  - title: "USHER: Holistic Interference Avoidance for Resource Optimized ML Inference"
+    badges: "Available"
+    repository_url: "https://github.com/ss7krd/Usher"
+
+  - title: "Flock: A Framework for Deploying On-Demand Distributed Trust"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/flock-org/flock"
+
+  - title: "DistLLM: Disaggregating Prefill and Decoding for Goodput-optimized Large Language Model Serving"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/LLMServe/DistServe/blob/camera-ready/distserve/evaluation/docs/README-AE.md"
+
+  - title: "Cuber: Constraint-Guided Parallelization Plan Generation for Deep Learning Training"
+    badges: "Available,Functional"
+    repository_url: "http://github.com/microsoft/nnscaler"
+
+  - title: "Enabling Tensor Language Model to Assist in Generating High-Performance Tensor Programs for Deep Learning"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/zhaiyi000/tlm"
+
+  - title: "Bitter: Enabling Efficient Low-Precision Deep Learning Computing through Hardware-aware Tensor Transformation"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/microsoft/BitBLAS/tree/osdi24_ladder_artifact"
+
+  - title: "Nomad: Non-Exclusive Memory Tiering via Transactional Page Migration"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/lingfenghsiang/Nomad"
+
+  - title: "InfiniGen: Efficient Generative Inference of Large Language Models with Dynamic KV Cache Management"
+    badges: "Available,Functional,Reproduced"
+    repository_url: "https://github.com/snu-comparch/InfiniGen"
+
+  - title: "IntOS: Persistent Embedded Operating System and Language Support for Multi-threaded Intermittent Computing"
+    badges: "Available,Functional"
+    repository_url: "https://github.com/yiluwusbu/IntOS"
+
 ---
-
-
-<style>
-table th:first-of-type {
-    width: 60%;
-    margin-top:10px;
-    margin-bottom:10px;
-}
-table th:nth-of-type(2) {
-    width: 20%;
-    margin-top:10px;
-    margin-bottom:10px;
-}
-table th:nth-of-type(3) {
-    width: 20%;
-    margin-top:10px;
-    margin-bottom:10px;
-}
-
-table td {
-    padding:0.25em;
-}
-
-span#aa {
-    background-color:#f15c24;
-    color:#FFFFFF;
-    font-weight: bold;
-    display: inline-block;
-    margin: 0px 0px 0px 0px;
-    width:100%;
-}
-
-span#af {
-    background-color:#1274bb;
-    color:#FFFFFF;
-    font-weight: bold;
-    display: inline-block;
-    margin: 0px 0px 0px 0px;
-    width:100%;
-}
-
-span#rr {
-    background-color:#6c4099;
-    color:#FFFFFF;
-    font-weight: bold;
-    display: inline-block;
-    margin: 0px 0px 0px 0px;
-    width:100%;
-}
-
-</style>
 
 **Submissions**: 34 (69% of accepted papers)
 
@@ -62,40 +156,48 @@ span#rr {
 * 31 Artifact Functional
 * 25 Results Reproduced
 
-| Paper title | Awarded Badges | Available at |
-|:-----------:|:--------------:|:------------:|
-| [Data-flow Availability: Achieving Timing Assurance on Autonomous Systems]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/WUSTL-CSPL/Shore-Userspace) |
-| [Taming Throughput-Latency Tradeoff in LLM Inference with Sarathi-Serve]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://anonymous.4open.science/r/sarathi-serve-osdi-artifact-5EB8/) |
-| [Detecting Logic Bugs in Database Engines via Equivalent Expression Transformation]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/JZuming/EET)|
-| [Caravan: Practical Online Learning of In-Network ML Models with Labeling Agents]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/Per-Packet-AI/Caravan-Artifact-OSDI24) |
-| [Automatic and Efficient Customization of Neural Networks for ML Applications]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/UChi-JCL/chameleonAPI) |
-| [Fairness in Serving Large Language Models]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span> | [Github](git@github.com:Ying1123/VTC-artifact.git) |
-| [Anvil: Verifying Liveness of Cluster Management Controllers]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/vmware-research/verifiable-controllers) |
-| [Managing Memory Tiers with CXL in Virtualized Environments]() | <span id="aa">AVAILABLE</span> | [Bitbucket](https://bitbucket.org/yuhong_zhong/memstrata/src/master/) |
-| [Sabre: Improving Memory Prefetching in Serverless MicroVMs with Near-Memory Hardware-Accelerated Compression]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/barabanshek/sabre) |
-| [IronSpec: Increasing the Reliability of Formal Specifications]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/GLaDOS-Michigan/IronSpec) |
-| [VeriSMo: A Verified Security Module for Confidential VMs]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span> | [Github](https://github.com/microsoft/verismo)|
-| [Inductive Invariants That Spark Joy: Using Invariant Taxonomies to Streamline Distributed Systems Proofs]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/GLaDOS-Michigan/Kondo-Artifact-OSDI24) |
-| [Parrot: Efficient Serving of LLM-based Applications with Semantic Variable]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/microsoft/ParrotServe/tree/artifact) |
-| [Anon: an FPGA-Based Collective Engine for Distributed Applications]() | <span id="aa">AVAILABLE</span> | [Github](https://github.com/Xilinx/ACCL/tree/dev) |
-| [DSig: Breaking the Barrier of Signatures in Data Centers]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/LPD-EPFL/dsig-artifacts) |
-| [𝜇Slope: High Compression and Fast Search on Semi-Structured Logs]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Zonodo](https://zenodo.org/records/11069592) |
-| [DRust: Language-Guided Distributed Shared Memory with Fine Granularity, Full Transparency, and Ultra Efficiency]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/uclasystem/DRust) |
-| [Beaver: Practical Partial Snapshots for Distributed Cloud Services]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/eniac/Beaver) |
-| [Llumnix: Dynamic Scheduling for Large Language Model Serving]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/alibaba/llm-scheduling-artifact) |
-| [dLoRA: Dynamically Orchestrating Requests and Adapters for LoRA LLM Serving]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/LLMServe/dLoRA-artifact) |
-| [Performance Interfaces for Hardware Accelerators]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/dslab-epfl/lpn) |
-| [What will it take for Johnny to know when his Cloud job will finish? Towards providing reliable job completion time predictions using PCS]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/abdullahfsm/PCS/tree/osdi2024-artifact) |
-| [Chop Chop: Byzantine Atomic Broadcast to the Network Limit]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span> | [Github](https://github.com/Distributed-EPFL/chop-chop-osdi24?tab=readme-ov-file) |
-| [Secret Key Recovery in a Global-Scale End-to-End Encryption System]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/vivi/SecureValueRecovery2/tree/artifact/paper_experiments#readme) |
-| [SquirrelFS: using the Rust compiler to check file-system crash consistency]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span> | [Github](https://github.com/hayley-leblanc/squirrelfs) |
-| [USHER: Holistic Interference Avoidance for Resource Optimized ML Inference]() | <span id="aa">AVAILABLE</span> | [Github](https://github.com/ss7krd/Usher) |
-| [Flock: A Framework for Deploying On-Demand Distributed Trust]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/flock-org/flock) |
-| [DistLLM: Disaggregating Prefill and Decoding for Goodput-optimized Large Language Model Serving]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/LLMServe/DistServe/blob/camera-ready/distserve/evaluation/docs/README-AE.md) |
-| [Cuber: Constraint-Guided Parallelization Plan Generation for Deep Learning Training]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span> | [Github](http://github.com/microsoft/nnscaler) |
-| [Enabling Tensor Language Model to Assist in Generating High-Performance Tensor Programs for Deep Learning]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/zhaiyi000/tlm) |
-| [Bitter: Enabling Efficient Low-Precision Deep Learning Computing through Hardware-aware Tensor Transformation]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/microsoft/BitBLAS/tree/osdi24_ladder_artifact) |
-| [Nomad: Non-Exclusive Memory Tiering via Transactional Page Migration]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/lingfenghsiang/Nomad) |
-| [InfiniGen: Efficient Generative Inference of Large Language Models with Dynamic KV Cache Management]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span><br><span id="rr">REPRODUCED</span> | [Github](https://github.com/snu-comparch/InfiniGen) |
-| [IntOS: Persistent Embedded Operating System and Language Support for Multi-threaded Intermittent Computing]() | <span id="aa">AVAILABLE</span><br><span id="af">FUNCTIONAL</span> | [Github](https://github.com/yiluwusbu/IntOS) |
-
+<table>
+  <thead>
+    <tr>
+      <th>Paper</th>
+      <th width="75px">Avail.</th>
+      <th width="75px">Funct.</th>
+      <th width="75px">Repro.</th>
+      <th>Available At</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% assign sorted_artifacts = page.artifacts | sort: "title" %}
+  {% for artifact in sorted_artifacts %}
+    <tr>
+      <td>
+        {{ artifact.title }}
+      </td>
+      <td width="75px">
+        {% if artifact.badges contains "Available" %}
+          <img src="{{ site.baseurl }}/images/{{ page.available_img }}" alt="{{ page.available_name }}">
+        {% endif %}
+      </td>
+      <td width="75px">
+        {% if artifact.badges contains "Functional" %}
+          <img src="{{ site.baseurl }}/images/{{ page.functional_img }}" alt="{{ page.functional_name }}">
+        {% endif %}
+      </td>
+      <td width="75px">
+        {% if artifact.badges contains "Reproduced" %}
+          <img src="{{ site.baseurl }}/images/{{ page.reproduced_img }}" alt="{{ page.reproduced_name }}">
+        {% endif %}
+      </td>
+      <td width="120px">
+        {% if artifact.artifact_url %}
+          <a href="{{artifact.artifact_url}}" target="_blank">Artifact</a><br>
+        {% endif %} {% if artifact.repository_url %}
+          <a href="{{artifact.repository_url}}" target="_blank">Repository</a><br>
+        {% endif %} {% if artifact.appendix_url %}
+          <a href="{{artifact.appendix_url}}" target="_blank">Appendix</a><br>
+        {% endif %}
+      </td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>

--- a/_conferences/sc2021/results.md
+++ b/_conferences/sc2021/results.md
@@ -10,332 +10,332 @@ reproduced_name: "Results Reproduced (v1.1)"
 baseurl: "https://dl.acm.org/doi/"
 artifacts:
 - title: "Temporal Vectorization for Stencils"
-  artifact_doi: "10.5281/zenodo.5151491"
+  artifact_url: "10.5281/zenodo.5151491"
   badges: available, functional
   paper_doi: "3458817.3476149"
 
 - title: "LCCG: A Locality-Centric Hardware Accelerator for High Throughput of Concurrent Graph Processing"
-  artifact_doi: "10.5281/zenodo.5155769"
+  artifact_url: "10.5281/zenodo.5155769"
   badges: available, functional, reproduced
   paper_doi: "3458817.3480854"
 
 - title: "Parallel Construction of Module Networks"
-  artifact_doi: "10.5281/zenodo.5144438"
+  artifact_url: "10.5281/zenodo.5144438"
   badges: available, functional, reproduced
   paper_doi: "3458817.3476207"
 
 - title: "Online Evolutionary Batch Size Orchestration for Scheduling Deep Learning Workloads in GPU Clusters"
-  artifact_doi: "10.5281/zenodo.5513082"
+  artifact_url: "10.5281/zenodo.5513082"
   badges: available, functional, reproduced
   paper_doi: "3458817.3480859"
 
 - title: "Krill: A Compiler and Runtime System for Concurrent Graph Processing"
-  artifact_doi: "10.5281/zenodo.5165762"
+  artifact_url: "10.5281/zenodo.5165762"
   badges: available, functional, reproduced
   paper_doi: "3458817.3476159"
 
 - title: "Exploiting User Activeness for Data Retention in HPC Systems"
-  artifact_doi: "10.5281/zenodo.5168853"
+  artifact_url: "10.5281/zenodo.5168853"
   badges: available, functional
   paper_doi: "3458817.3476201"
 
 - title: "LogECMem: Coupling Erasure-Coded In-Memory Key-Value Stores with Parity Logging"
-  artifact_doi: "10.5281/zenodo.5092219"
+  artifact_url: "10.5281/zenodo.5092219"
   badges: available
   paper_doi: "3458817.3480852"
 
 - title: "KAISA: An Adaptive Second-order Optimizer Framework for Deep Neural Networks"
-  artifact_doi: "10.5281/zenodo.4895203"
+  artifact_url: "10.5281/zenodo.4895203"
   badges: available, functional
   paper_doi: "3458817.3476152"
 
 - title: "Understanding, Predicting and Scheduling Serverless Workloads under Partial Interference"
-  artifact_doi: "10.5281/zenodo.5147569"
+  artifact_url: "10.5281/zenodo.5147569"
   badges: available
   paper_doi: "3458817.3476215"
 
 - title: "Cuttlefish: Library for Achieving Energy Efficiency in Multicore Parallel Programs"
-  artifact_doi: "10.5281/zenodo.5167629"
+  artifact_url: "10.5281/zenodo.5167629"
   badges: available, functional, reproduced
   paper_doi: "3458817.3476163"
 
 - title: "Accelerating XOR-based Erasure Coding using Program Optimization Techniques"
-  artifact_doi: "10.5281/zenodo.5167006"
+  artifact_url: "10.5281/zenodo.5167006"
   badges: available, functional, reproduced
   paper_doi: "3458817.3476204"
 
 - title: "Accelerating Applications using Edge Tensor Processing Units"
-  artifact_doi: "10.5281/zenodo.5156431"
+  artifact_url: "10.5281/zenodo.5156431"
   badges: available, functional, reproduced
   paper_doi: "3458817.3476177"
 
 - title: "On the Parallel I/O Optimality of Linear Algebra Kernels: Near-Optimal Matrix Factorizations"
-  artifact_doi: "10.5281/zenodo.5168027"
+  artifact_url: "10.5281/zenodo.5168027"
   badges: available, functional, reproduced
   paper_doi: "3458817.3476167"
 
 - title: "SV-Sim: Scalable PGAS-based State Vector Simulation of Quantum Circuits"
-  artifact_doi: "10.5281/zenodo.5206960"
+  artifact_url: "10.5281/zenodo.5206960"
   badges: available, functional
   paper_doi: "3458817.3476169"
 
 - title: "DeltaFS: A Scalable No-Ground-Truth Filesystem For Massively-Parallel Computing"
-  artifact_doi: "10.5281/zenodo.4884852"
+  artifact_url: "10.5281/zenodo.4884852"
   badges: available, functional
   paper_doi: "3458817.3476148"
 
 - title: "Reducing Redundancy in Data Organization and Arithmetic Calculation for Stencil Computations"
-  artifact_doi: "10.5281/zenodo.3881644"
+  artifact_url: "10.5281/zenodo.3881644"
   badges: available
   paper_doi: "3458817.3476154"
 
 - title: "CAKE: Matrix Multiplication Using Constant-Bandwidth Blocks"
-  artifact_doi: "10.5281/zenodo.5148715"
+  artifact_url: "10.5281/zenodo.5148715"
   badges: available, functional, reproduced
   paper_doi: "3458817.3476166"
 
 - title: "Hardware-supported Remote Persistence for Distributed Persistent Memory"
-  artifact_doi: "10.5281/zenodo.5162688"
+  artifact_url: "10.5281/zenodo.5162688"
   badges: available, functional, reproduced
   paper_doi: "3458817.3476194"
 
 - title: "STM-Multifrontal QR: Streaming Task Mapping Multifrontal QR Factorization Empowered by GCN"
-  artifact_doi: "10.5281/zenodo.5144709"
+  artifact_url: "10.5281/zenodo.5144709"
   badges: available, functional, reproduced
   paper_doi: "3458817.3476199"
 
 - title: "Clairvoyant Prefetching for Distributed Machine Learning I/O"
-  artifact_doi: "10.5281/zenodo.5166929"
+  artifact_url: "10.5281/zenodo.5166929"
   badges: available
   paper_doi: "3458817.3476181"
 
 - title: "Discovering and Balancing Fundamental Cycles in Large Signed Graphs"
-  artifact_doi: "10.5281/zenodo.5148797"
+  artifact_url: "10.5281/zenodo.5148797"
   badges: available, functional, reproduced
   paper_doi: "3458817.3476153"
 
 - title: "High Performance Uncertainty Quantification with Parallelized Multilevel Markov Chain Monte Carlo"
-  artifact_doi: "10.5281/zenodo.5158988"
+  artifact_url: "10.5281/zenodo.5158988"
   badges: available
   paper_doi: "3458817.3476150"
 
 - title: "3D Acoustic-Elastic Coupling with Gravity: The Dynamics of the 2018 Palu, Sulawesi Earthquake and Tsunami"
-  artifact_doi: "10.5281/zenodo.5159333"
+  artifact_url: "10.5281/zenodo.5159333"
   badges: available, functional, reproduced
   paper_doi: "3458817.3476173"
 
 - title: "Enable Simultaneous DNN Services Based on Deterministic Operator Overlap and Precise Latency Prediction"
-  artifact_doi: "10.5281/zenodo.5176097"
+  artifact_url: "10.5281/zenodo.5176097"
   badges: available, functional, reproduced
   paper_doi: "3458817.3476143"
 
 - title: "Index Launches: Scalable, Flexible Representation of Parallel Task Groups"
-  artifact_doi: "10.5281/zenodo.5164404"
+  artifact_url: "10.5281/zenodo.5164404"
   badges: available, functional, reproduced
   paper_doi: "3458817.3476175"
 
 - title: "PAGANI: A Parallel Adaptive GPU Algorithm for Numerical Integration full strip note"
-  artifact_doi: "10.5281/zenodo.5204819"
+  artifact_url: "10.5281/zenodo.5204819"
   badges: available, functional, reproduced
   paper_doi: "3458817.3476198"
 
 - title: "Minimizing privilege for building HPC containers"
-  artifact_doi: "10.6084/m9.figshare.14396099"
+  artifact_url: "10.6084/m9.figshare.14396099"
   badges: available, functional, reproduced
   paper_doi: "3458817.3476187"
 
 - title: "Efficient Tensor Core-based GPU Kernels for Structured Sparsity under Reduced Precision"
-  artifact_doi: "10.5281/zenodo.5136675"
+  artifact_url: "10.5281/zenodo.5136675"
   badges: available, functional, reproduced
   paper_doi: "3458817.3476182"
 
 - title: "Preparing an Incompressible-Flow Fluid Dynamics Code for Exascale-Class Wind Energy Simulations"
-  artifact_doi: "10.5281/zenodo.4899910"
+  artifact_url: "10.5281/zenodo.4899910"
   badges: available, functional, reproduced
   paper_doi: "3458817.3476185"
 
 - title: "Efficient Large-Scale Language Model Training on GPU Clusters"
-  artifact_doi: "10.5281/zenodo.5181820"
+  artifact_url: "10.5281/zenodo.5181820"
   badges: available, functional
   paper_doi: "3458817.3476209"
 
 - title: "Pinpointing Crash-Consistency Bugs in the HPC I/O Stack: A Cross-Layer Approach"
-  artifact_doi: "10.5281/zenodo.5168471"
+  artifact_url: "10.5281/zenodo.5168471"
   badges: available, functional
   paper_doi: "3458817.3476144"
 
 - title: "AgEBO-Tabular: Joint Neural Architecture and Hyperparameter Search with Autotuned Data-Parallel Training for Tabular Data full strip note"
-  artifact_doi: "10.5281/zenodo.4094667"
+  artifact_url: "10.5281/zenodo.4094667"
   badges: available
   paper_doi: "3458817.3476203"
 
 - title: "Bootstrapping In-situ Workflow Auto-Tuning via Combining Performance Models of Component Applications full strip note"
-  artifact_doi: "10.5281/zenodo.5003901"
+  artifact_url: "10.5281/zenodo.5003901"
   badges: available, functional
   paper_doi: "3458817.3476197"
 
 - title: "Systematically Inferring I/O Performance Variability by Examining Repetitive Job Behavior"
-  artifact_doi: "10.5281/zenodo.5236852"
+  artifact_url: "10.5281/zenodo.5236852"
   badges: available, functional, reproduced
   paper_doi: "3458817.3476186"
 
 - title: "MAPA: Multi-Accelerator Pattern Allocation Policy for Multi-Tenant GPU Servers"
-  artifact_doi: "10.5281/zenodo.5152741"
+  artifact_url: "10.5281/zenodo.5152741"
   badges: available, functional
   paper_doi: "3458817.3480853"
 
 - title: "Productivity, Portability, Performance: Data-Centric Python"
-  artifact_doi: "10.5281/zenodo.5155509"
+  artifact_url: "10.5281/zenodo.5155509"
   badges: available, functional, reproduced
   paper_doi: "3458817.3476176"
 
 - title: "Flare: Flexible In-Network Allreduce"
-  artifact_doi: "10.5281/zenodo.4836022"
+  artifact_url: "10.5281/zenodo.4836022"
   badges: available, functional, reproduced
   paper_doi: "3458817.3476178"
 
 - title: "Non-Recurring Engineering (NRE) Best Practices: A Case Study with the NERSC/NVIDIA OpenMP Contract"
-  artifact_doi: "10.5281/zenodo.5168093"
+  artifact_url: "10.5281/zenodo.5168093"
   badges: available
   paper_doi: "3458817.3476213"
 
 - title: "SEEC: Stochastic Escape Express Channel"
-  artifact_doi: "10.5281/zenodo.5171429"
+  artifact_url: "10.5281/zenodo.5171429"
   badges: available, functional, reproduced
   paper_doi: "3458817.3476140"
 
 - title: "APNN-TC: Accelerating Arbitrary Precision Neural Networks on Ampere GPU Tensor Cores"
-  artifact_doi: "10.5281/zenodo.5144378"
+  artifact_url: "10.5281/zenodo.5144378"
   badges: available, functional, reproduced
   paper_doi: "3458817.3476157"
 
 - title: "Paths to OpenMP in the Kernel"
-  artifact_doi: "10.5281/zenodo.5164666"
+  artifact_url: "10.5281/zenodo.5164666"
   badges: available
   paper_doi: "3458817.3476183"
 
 - title: "The Hidden cost of the Edge: A Performance Comparison ofEdge and Cloud Latencies"
-  artifact_doi: "10.5281/zenodo.5163851"
+  artifact_url: "10.5281/zenodo.5163851"
   badges: available, functional, reproduced
   paper_doi: "3458817.3476142"
 
 - title: "Scalable adaptive PDE solvers in arbitrary domains"
-  artifact_doi: "10.5281/zenodo.5168313"
+  artifact_url: "10.5281/zenodo.5168313"
   badges: available
   paper_doi: "3458817.3476220"
 
 - title: "ZeRO-Infinity: Breaking the GPU Memory Wall for Extreme Scale Deep Learning"
-  artifact_doi: "10.5281/zenodo.5156596"
+  artifact_url: "10.5281/zenodo.5156596"
   badges: available, functional
   paper_doi: "3458817.3476205"
 
 - title: "Accelerating large scale de novo metagenome assembly using GPUs"
-  artifact_doi: "10.5281/zenodo.5165333"
+  artifact_url: "10.5281/zenodo.5165333"
   badges: available, functional, reproduced
   paper_doi: "3458817.3476212"
 
 - title: "Online Optimization of File Transfers in High-Speed Networks"
-  artifact_doi: "10.5281/zenodo.5164277"
+  artifact_url: "10.5281/zenodo.5164277"
   badges: available
   paper_doi: "3458817.3476208"
 
 - title: "In-Depth Analyses of Unified Virtual Memory System for GPU Accelerated Computing"
-  artifact_doi: "10.5281/zenodo.5148930"
+  artifact_url: "10.5281/zenodo.5148930"
   badges: available, functional, reproduced
   paper_doi: "3458817.3480855"
 
 - title: "HatRPC: Hint-Accelerated Thrift RPC over RDMA"
-  artifact_doi: "10.5281/zenodo.5203281"
+  artifact_url: "10.5281/zenodo.5203281"
   badges: available
   paper_doi: "3458817.3476191"
 
 - title: "Characterization and Prediction of Deep Learning Workloads in Large-Scale GPU Datacenters"
-  artifact_doi: "10.5281/zenodo.5116412"
+  artifact_url: "10.5281/zenodo.5116412"
   badges: available, functional, reproduced
   paper_doi: "3458817.3476223"
 
 - title: "Reverse-Mode Automatic Differentiation and Optimization of GPU Kernels via Enzyme full strip note"
-  artifact_doi: "10.5281/zenodo.5147573"
+  artifact_url: "10.5281/zenodo.5147573"
   badges: available, functional, reproduced
   paper_doi: "3458817.3476165"
 
 - title: "LibShalom: Optimizing Small and Irregular-shaped Matrix Multiplications on ARMv8 Multi-Cores"
-  artifact_doi: "10.5281/zenodo.5201457"
+  artifact_url: "10.5281/zenodo.5201457"
   badges: available
   paper_doi: "3458817.3476217"
 
 - title: "Simurgh: A Fully Decentralized and Secure NVMM User Space File System"
-  artifact_doi: "10.5281/zenodo.5163624"
+  artifact_url: "10.5281/zenodo.5163624"
   badges: available, functional, reproduced
   paper_doi: "3458817.3476180"
 
 - title: "HPAC: Evaluating Approximate Computing Techniques on HPC OpenMP Applications."
-  artifact_doi: "10.5281/zenodo.5167980"
+  artifact_url: "10.5281/zenodo.5167980"
   badges: available, functional, reproduced
   paper_doi: "3458817.3476216"
 
 - title: "Ribbon: Cost-Effective and QoS-Aware Deep Learning Model Inference using a Diverse Pool of Cloud Computing Instances"
-  artifact_doi: "10.5281/zenodo.5262865"
+  artifact_url: "10.5281/zenodo.5262865"
   badges: available, functional, reproduced
   paper_doi: "3458817.3476168"
 
 - title: "Lunule: An Agile and Judicious Metadata Load Balancer for CephFS"
-  artifact_doi: "10.5281/zenodo.5171833"
+  artifact_url: "10.5281/zenodo.5171833"
   badges: available
   paper_doi: "3458817.3476196"
 
 - title: "A Next-Generation Discontinuous Galerkin Fluid Dynamics Solver with Application to High-Resolution Lung Airflow Simulations"
-  artifact_doi: "10.5281/zenodo.5176507"
+  artifact_url: "10.5281/zenodo.5176507"
   badges: available
   paper_doi: "3458817.3476171"
 
 - title: "LMFF: Efficient and Scalable Layered Materials Force Field on Heterogeneous Many-Core Processors"
-  artifact_doi: "10.5281/zenodo.5203181"
+  artifact_url: "10.5281/zenodo.5203181"
   badges: available, functional
   paper_doi: "3458817.3476137"
 
 - title: "Whale: Efficient One-to-Many Data Partitioning in RDMA-assisted Distributed Stream Processing Systems"
-  artifact_doi: "10.5281/zenodo.4897500"
+  artifact_url: "10.5281/zenodo.4897500"
   badges: available
   paper_doi: "3458817.3476192"
 
 - title: "ndzip-gpu: Efficient Lossless Compression of Scientific Floating-Point Data on GPUs"
-  artifact_doi: "10.5281/zenodo.5144874"
+  artifact_url: "10.5281/zenodo.5144874"
   badges: available, functional, reproduced
   paper_doi: "3458817.3476224"
 
 - title: "cuTS: Scaling Subgraph Isomorphism on Distributed Multi-GPU Systems Using Trie Based Data Structure"
-  artifact_doi: "10.5281/zenodo.5154114"
+  artifact_url: "10.5281/zenodo.5154114"
   badges: available, functional, reproduced
   paper_doi: "3458817.3476214"
 
 - title: "Representation of Women in High-Performance Computing Conferences"
-  artifact_doi: "10.1145/3476480"
+  artifact_url: "10.1145/3476480"
   badges: available, functional, reproduced
   paper_doi: "3458817.3476164"
 
 - title: "PEPPA-X: finding program test inputs to bound silent data corruption vulnerability in HPC applications"
-  artifact_doi: "10.1145/3476481"
+  artifact_url: "10.1145/3476481"
   badges: available, functional, reproduced
   paper_doi: "3458817.3476147"
 
 - title: "Tensor processing primitives: a programming abstraction for efficiency and portability in deep learning workloads"
-  artifact_doi: "10.1145/3476482"
+  artifact_url: "10.1145/3476482"
   badges: available, functional, reproduced
   paper_doi: "3458817.3476206"
 
 - title: "DistGNN: scalable distributed training for large-scale graph neural networks"
-  artifact_doi: "10.1145/3476483"
+  artifact_url: "10.1145/3476483"
   badges: available, functional
   paper_doi: "3458817.3480856"
 
 - title: "Dr. Top-k: delegate-centric Top-k on GPUs"
-  artifact_doi: "10.1145/3476484"
+  artifact_url: "10.1145/3476484"
   badges: available, functional
   paper_doi: "3458817.3476141"
 
 - title: "Hybrid, scalable, trace-driven performance modeling of GPGPUs"
-  artifact_doi: "10.1145/3476485"
+  artifact_url: "10.1145/3476485"
   badges: available, functional, reproduced
   paper_doi: "3458817.3476221"
 
@@ -403,8 +403,8 @@ artifacts:
       <td>
         {% if artifact.award %}
           <b>Distinguished&nbsp;Artifact</b><br>
-        {% endif %} {% if artifact.artifact_doi %}
-          <a href="https://doi.org/{{artifact.artifact_doi}}" target="_blank">Artifact</a><br>
+        {% endif %} {% if artifact.artifact_url %}
+          <a href="https://doi.org/{{artifact.artifact_url}}" target="_blank">Artifact</a><br>
         {% endif %}
       </td>
     </tr>

--- a/_conferences/sosp2021/results.md
+++ b/_conferences/sosp2021/results.md
@@ -11,32 +11,32 @@ baseurl: "https://dl.acm.org/doi/"
 artifacts:
 
   - title: "Boki: Stateful Serverless Computing with Shared Logs"
-    github_url: "https://github.com/ut-osa/boki-benchmarks"
+    repository_url: "https://github.com/ut-osa/boki-benchmarks"
     badges: Available, Functional, Reproduced
     summary: boki
     doi: "10.1145/3477132.3483541"
 
   - title: "Understanding and Detecting Software Upgrade Failures in Distributed Systems"
-    github_url: "https://github.com/zlab-purdue/ds-upgrade"
+    repository_url: "https://github.com/zlab-purdue/ds-upgrade"
     additional_urls:
       - "https://github.com/jwjwyoung/DUPChecker"
       - "https://gitlab.dsrg.utoronto.ca/zhuqi/DUPTester"
-    jupyter_url: "https://github.com/jwjwyoung/RecentUpgradeFailureStudy"
-    vm_url: "http://nas.dsrg.utoronto.ca:8080/share.cgi?ssid=0Sa7AQ1&fbclid=IwAR2XxgwGi34aP7m-LgnevZBrN4PBW9KRcnTItEtWTNX0s2XpUVP2m3PZykY"
+      - "https://github.com/jwjwyoung/RecentUpgradeFailureStudy"
+      - "http://nas.dsrg.utoronto.ca:8080/share.cgi?ssid=0Sa7AQ1&fbclid=IwAR2XxgwGi34aP7m-LgnevZBrN4PBW9KRcnTItEtWTNX0s2XpUVP2m3PZykY"
     badges: Available, Functional, Reproduced
     summary: duptester
     doi: "10.1145/3477132.3483577"
 
   - title: "Gradient Compression Supercharged High-Performance Data Parallel DNN Training"
-    github_url: "https://gitlab.com/hipress/hipress"
+    repository_url: "https://gitlab.com/hipress/hipress"
     badges: Available, Functional, Reproduced
     summary: hipress
     doi: "10.1145/3477132.3483553"
 
   - title: "Formal Verification of a Multiprocessor Hypervisor on Arm Relaxed Memory Hardware"
-    github_url: "https://github.com/VeriGu/sosp-paper211-ae"
-    proof_url: "https://github.com/VeriGu/sosp-paper211-ae-proof"
+    repository_url: "https://github.com/VeriGu/sosp-paper211-ae"
     additional_urls:
+      - "https://github.com/VeriGu/sosp-paper211-ae-proof"
       - "https://github.com/VeriGu/usenix-ae-linux"
       - "https://github.com/VeriGu/vct-qemu"
     badges: Available, Functional, Reproduced
@@ -44,90 +44,93 @@ artifacts:
     doi: "10.1145/3477132.3483560"
 
   - title: "iGUARD: In-GPU Advanced Race Detection"
-    github_url: "https://github.com/csl-iisc/iGUARD"
+    repository_url: "https://github.com/csl-iisc/iGUARD"
     badges: Available, Functional, Reproduced
     summary: iguard
     doi: "10.1145/3477132.3483545"
 
   - title: "Forerunner: Constraint-based Speculative Transaction Execution for Ethereum"
-    github_url: "https://github.com/microsoft/Forerunner/"
+    repository_url: "https://github.com/microsoft/Forerunner/"
     badges: Available, Functional, Reproduced
     summary: forerunner
     doi: "10.1145/3477132.3483564"
 
   - title: "Crash Consistent Non-Volatile Memory Express"
-    github_url: "https://github.com/thustorage/ccnvme"
+    repository_url: "https://github.com/thustorage/ccnvme"
     badges: Available, Functional, Reproduced
     summary: ccnvme
     doi: "10.1145/3477132.3483577"
 
   - title: "LineFS: Efficient SmartNIC Offload of a Distributed File System with Pipeline Parallelism"
-    github_url: "https://github.com/casys-kaist/LineFS"
+    repository_url: "https://github.com/casys-kaist/LineFS"
     badges: Available, Functional, Reproduced
     summary: linefs
     doi: "10.1145/3477132.3483565"
 
   - title: "When Idling is Ideal: Optimizing Tail-Latency for Highly-Dispersed Datacenter Workloads with Perséphone"
-    github_url: "https://github.com/maxdml/psp"
-    jupyter_url: "https://github.com/maxdml/psp/blob/master/sosp_aec/aec.ipynb"
+    repository_url: "https://github.com/maxdml/psp"
+    additional_urls:
+      - "https://github.com/maxdml/psp/blob/master/sosp_aec/aec.ipynb"
     badges: Available, Functional, Reproduced
     summary: perséphone
     doi: "10.1145/3477132.3483571"
 
   - title: "Exploiting Nil-Externality for Fast Replicated Storage"
-    bitbucket_url: "https://bitbucket.org/aganesan4/skyros/"
-    data_url: "https://zenodo.org/record/5520021"
+    repository_url: "https://bitbucket.org/aganesan4/skyros/"
+    additional_urls:
+      - "https://zenodo.org/record/5520021"
     badges: Available, Functional, Reproduced
     summary: skyros
     doi: "10.1145/3477132.3483543"
 
   - title: "Rabia: Simplifying State-Machine Replication Through Randomization"
-    github_url: "https://github.com/haochenpan/rabia/"
+    repository_url: "https://github.com/haochenpan/rabia/"
     cloudlab_url: "https://www.cloudlab.us/show-profile.php?uuid=1af34047-fb02-11eb-84f8-e4434b2381fc"
     badges: Available, Functional, Reproduced
     summary: rabia
     doi: "10.1145/3477132.3483582"
 
   - title: "Coeus: A system for oblivious document ranking and retrieval"
-    github_url: "https://github.com/ishtiyaque/Coeus_artifact"
+    repository_url: "https://github.com/ishtiyaque/Coeus_artifact"
     badges: Available, Functional, Reproduced
     summary: coeus
     doi: "10.1145/3477132.3483586"
 
   - title: "FragPicker: A New Defragmentation Tool for Modern Storage Devices"
-    github_url: "https://github.com/jonggyup/FragPicker"
+    repository_url: "https://github.com/jonggyup/FragPicker"
     badges: Available, Functional, Reproduced
     summary: fragpicker
     doi: "10.1145/3477132.3483593"
 
   - title: "J-NVM: Off-heap Persistent Objects in Java"
-    github_url: "https://github.com/jnvm-project/jnvm"
+    repository_url: "https://github.com/jnvm-project/jnvm"
     badges: Available, Functional, Reproduced
     summary: jnvm
     doi: "10.1145/3477132.3483579"
 
   - title: "Basil: Breaking up BFT with ACID (transactions)"
-    github_url: "https://github.com/fsuri/SOSP21_artifact_eval"
+    repository_url: "https://github.com/fsuri/SOSP21_artifact_eval"
     cloudlab_url: "https://www.cloudlab.us/p/morty/SOSP108"
     badges: Available, Functional, Reproduced
     summary: basil
     doi: "10.1145/3477132.3483552"
 
   - title: "Scale and Performance in a Filesystem Semi-Microkernel"
-    web_url: "https://research.cs.wisc.edu/adsl/Software/uFS/"
-    github_url: "https://github.com/WiscADSL/uFS"
-    badges: Available, Functional, Reproduced 
+    additional_urls:
+      - "https://research.cs.wisc.edu/adsl/Software/uFS/"
+    repository_url: "https://github.com/WiscADSL/uFS"
+    badges: Available, Functional, Reproduced
     summary: ufs
     doi: "10.1145/3477132.3483581"
 
   - title: "HeMem: Scalable Tiered Memory Management for Big Data Applications and Real NVM"
-    bitbucket_url: "https://bitbucket.org/ajaustin/hemem/src/sosp-submission/"
+    repository_url: "https://bitbucket.org/ajaustin/hemem/src/sosp-submission/"
     badges: Available, Functional, Reproduced
     summary: hemem
     doi: "10.1145/3477132.3483550"
 
   - title: "IODA: A Host/Device Co-Design for Strong Predictability Contract on Modern Flash Storage"
-    bitbucket_url: "https://github.com/huaicheng/IODA-SOSP21-AE"
+    repository_url: "https://github.com/huaicheng/IODA-SOSP21-AE"
     additional_urls:
       - "https://asciinema.org/a/431726"
     badges: Available, Functional, Reproduced
@@ -135,51 +138,51 @@ artifacts:
     doi: "10.1145/3477132.3483573"
 
   - title: "BIDL: A High-throughput, Low-latency Permissioned Blockchain Framework for Datacenter Networks"
-    github_url: "https://github.com/hku-systems/bidl"
+    repository_url: "https://github.com/hku-systems/bidl"
     badges: Available, Functional, Reproduced
     summary: bidl
     doi: "10.1145/3477132.3483574"
 
   - title: "Rudra: Finding Memory Safety Bugs in Rust at the Ecosystem Scale"
-    github_url: "https://github.com/sslab-gatech/Rudra-Artifacts"
+    repository_url: "https://github.com/sslab-gatech/Rudra-Artifacts"
     badges: Available, Functional, Reproduced
     summary: rudra
     award: yes
     doi: "10.1145/3477132.3483570"
 
   - title: "MIND: In-Network Memory Management for Disaggregated Data Centers"
-    github_url: "https://github.com/shsym/mind"
+    repository_url: "https://github.com/shsym/mind"
     badges: Available, Functional, Reproduced
     summary: mind
     doi: "10.1145/3477132.3483582"
- 
+
   - title: "Mycelium: Large-Scale Distributed Graph Queries with Differential Privacy"
-    github_url: "https://github.com/karannewatia/Mycelium"
+    repository_url: "https://github.com/karannewatia/Mycelium"
     summary: mycelium
     badges: Available, Functional, Reproduced
     summary: mycelium
     doi: "10.1145/3477132.3483585"
 
   - title: "Solving Large-Scale Granular Resource Allocation Problems Efficiently with POP"
-    github_url: "https://github.com/stanford-futuredata/POP"
+    repository_url: "https://github.com/stanford-futuredata/POP"
     badges: Available, Functional, Reproduced
     summary: pop
     doi: "10.1145/3477132.3483588"
 
   - title: "Snoopy: Surpassing the Scalability Bottleneck of Oblivious Storage"
-    github_url: "https://github.com/ucbrise/snoopy"
+    repository_url: "https://github.com/ucbrise/snoopy"
     badges: Available, Functional, Reproduced
     summary: snoopy
     doi: "10.1145/3477132.3483562"
 
   - title: "WineFS: a hugepage-aware file system for persistent memory that ages gracefully"
-    github_url: "https://github.com/rohankadekodi/WineFS"
+    repository_url: "https://github.com/rohankadekodi/WineFS"
     badges: Available, Functional, Reproduced
     summary: winefs
     doi: "10.1145/3477132.3483567"
 
   - title: "Caracal: Contention Management with Deterministic Concurrency Control"
-    github_url: "https://github.com/uoft-felis/felis"
+    repository_url: "https://github.com/uoft-felis/felis"
     additional_urls:
        - "https://github.com/uoft-felis/felis-controller"
     badges: Available, Functional, Reproduced
@@ -187,47 +190,47 @@ artifacts:
     doi: "10.1145/3477132.3483591"
 
   - title: "dSpace: Composable Abstractions for Smart Spaces"
-    github_url: "https://github.com/digi-project/sosp21-artifact"
+    repository_url: "https://github.com/digi-project/sosp21-artifact"
     badges: Available, Functional
     summary: dspace
     doi: "10.1145/3477132.3483559"
 
   - title: "The Aurora Single Level Store Operating System"
-    web_url: "https://rcs.uwaterloo.ca/aurora/"
-    github_url: "https://github.com/rcslab/aurora-12.1/"
-    scripts_url: "https://github.com/rcslab/aurora-bench/"
+    additional_url: "https://rcs.uwaterloo.ca/aurora/"
+    repository_url: "https://github.com/rcslab/aurora-12.1/"
     additional_urls:
       - "https://github.com/rcslab/aurora/"
+      - "https://github.com/rcslab/aurora-bench/"
     badges: Available, Functional
     summary: aurora
     doi: "10.1145/3477132.3483563"
 
   - title: "HEALER: Relation Learning Guided Kernel Fuzzing"
-    github_url: "https://github.com/SunHao-0/healer"
+    repository_url: "https://github.com/SunHao-0/healer"
     badges: Available, Functional
     summary: healer
     doi: "10.1145/3477132.3483547"
 
   - title: "Random Walks on Huge Graphs at Cache Efficiency"
-    github_url: "https://github.com/flashmobwalk/flashmob/tree/sosp21-ae"
+    repository_url: "https://github.com/flashmobwalk/flashmob/tree/sosp21-ae"
     badges: Available, Functional
     summary: flashmob
     doi: "10.1145/3477132.3483575"
 
   - title: "Geometric Partitioning: Explore the Boundary of Optimal Erasure Code Repair"
-    github_url: "https://github.com/rcstor/rcstor"
+    repository_url: "https://github.com/rcstor/rcstor"
     badges: Available, Functional
     summary: rcstor
     doi: "10.1145/3477132.3483558"
 
   - title: "Kauri: Scalable BFT Consensus with Pipelined Tree-Based Dissemination and Aggregation"
-    github_url: "https://github.com/Raycoms/Kauri-Public"
+    repository_url: "https://github.com/Raycoms/Kauri-Public"
     badges: Available, Functional
     summary: kauri
     doi: "10.1145/3477132.3483584"
 
   - title: "Kangaroo: Caching Billions of Tiny Objects on Flash"
-    github_url: "https://github.com/saramcallister/Kangaroo"
+    repository_url: "https://github.com/saramcallister/Kangaroo"
     additional_urls:
       - "https://github.com/saramcallister/CacheLib-1"
     badges: Available, Functional
@@ -235,25 +238,25 @@ artifacts:
     doi: "10.1145/3477132.3483568"
 
   - title: "Witcher: Systematic Crash Consistency Testing for Non-Volatile Memory Key-Value Stores"
-    github_url: "https://github.com/cosmoss-vt/witcher"
+    repository_url: "https://github.com/cosmoss-vt/witcher"
     badges: Available, Functional
     summary: witcher
     doi: "10.1145/3477132.3483556"
 
   - title: "PACTree: A High Performance Persistent Range Index Using PAC Guidelines"
-    github_url: "https://github.com/cosmoss-vt/pactree"
+    repository_url: "https://github.com/cosmoss-vt/pactree"
     badges: Available, Functional
     summary: pactree
     doi: "10.1145/3477132.3483589"
 
   - title: "Automated SmartNIC Offloading Insights for Network Functions"
-    github_url: "https://github.com/824728350/Clara"
+    repository_url: "https://github.com/824728350/Clara"
     badges: Available, Functional
     summary: clara
     doi: "10.1145/3477132.3483583"
 
   - title: "Snowboard: Finding Kernel Concurrency Bugs through Systematic Inter-thread Communication Analysis"
-    github_url: "https://github.com/rssys/snowboard"
+    repository_url: "https://github.com/rssys/snowboard"
     badges: Available, Functional
     summary: snowboard
     doi: "10.1145/3477132.3483549"
@@ -264,7 +267,7 @@ artifacts:
     doi: "10.1145/3477132.3483557"
 
   - title: "Regular Sequential Serializability and Regular Sequential Consistency"
-    github_url: "https://github.com/jmhelt/tapir/tree/spanner"
+    repository_url: "https://github.com/jmhelt/tapir/tree/spanner"
     additional_urls:
       - "https://github.com/princeton-sns/gryff/tree/rs"
     badges: Available
@@ -272,7 +275,7 @@ artifacts:
     doi: "10.1145/3477132.3483566"
 
   - title: "The Demikernel Library OS Architecture for Microsecond, Kernel-Bypass Datacenter Systems"
-    github_url: "https://github.com/demikernel/demikernel"
+    repository_url: "https://github.com/demikernel/demikernel"
     cloudlab_url: "https://www.cloudlab.us/p/Demeter/testing-pair/9"
     additional_urls:
       - "https://github.com/demikernel/echo"
@@ -323,24 +326,10 @@ artifacts:
       <td>
         {% if artifact.award %}
           <b>Distinguished&nbsp;Artifact</b><br>
-        {% endif %} {% if artifact.web_url %}
-          <a href="{{artifact.web_url}}">Web</a><br>
-        {% endif %} {% if artifact.github_url %}
-          <a href="{{artifact.github_url}}">GitHub</a><br>
-        {% endif %} {% if artifact.bitbucket_url %}
-          <a href="{{artifact.bitbucket_url}}">Bitbucket</a><br>
-        {% endif %} {% if artifact.data_url %}
-          <a href="{{artifact.data_url}}">Data</a><br>
-        {% endif %} {% if artifact.jupyter_url %}
-          <a href="{{artifact.jupyter_url}}">Jupyter&nbsp;Notebook</a><br>
-        {% endif %} {% if artifact.proof_url %}
-          <a href="{{artifact.proof_url}}">Proofs</a><br>
-        {% endif %} {% if artifact.vm_url %}
-          <a href="{{artifact.vm_url}}">VM&nbsp;Image</a><br>
+        {% endif %} {% if artifact.repository_url %}
+          <a href="{{artifact.repository_url}}">GitHub</a><br>
         {% endif %} {% if artifact.cloudlab_url %}
           <a href="{{artifact.cloudlab_url}}">CloudLab&nbsp;Profile</a><br>
-        {% endif %} {% if artifact.scripts_url %}
-          <a href="{{artifact.scripts_url}}">Scripts</a><br>
         {% endif %} {% if artifact.additional_urls %}
           {% for url in artifact.additional_urls %}
             <a href="{{url}}">Additional&nbsp;Resources</a><br>

--- a/_conferences/sosp2023/results.md
+++ b/_conferences/sosp2023/results.md
@@ -11,201 +11,202 @@ baseurl: "https://dl.acm.org/doi/"
 artifacts:
 
   - title: "Acto: Automatic End-to-End Testing for Operation Correctness of Cloud System Management"
-    github_url: "https://github.com/xlab-uiuc/acto/tree/sosp-ae"
+    repository_url: "https://github.com/xlab-uiuc/acto/tree/sosp-ae"
     badges: Available, Functional, Reproduced
     summary: acto
     doi: "10.1145/3600006.3613161"
 
   - title: "Bagpipe: Accelerating Deep Recommendation Model Training"
-    github_url: "https://github.com/iidsample/bagpipe_artifacts"
+    repository_url: "https://github.com/iidsample/bagpipe_artifacts"
     badges: Available, Functional, Reproduced
     summary: bagpipe
     doi: "10.1145/3600006.3613142"
 
   - title: "Cornflakes: Zero-Copy Serialization for Microsecond-Scale Networking"
-    github_url: "https://github.com/deeptir18/cornflakes"
-    scripts_url: "https://github.com/deeptir18/cornflakes-scripts"
+    repository_url: "https://github.com/deeptir18/cornflakes"
+    additional_urls:
+      - "https://github.com/deeptir18/cornflakes-scripts"
     cloudlab_url: "https://www.cloudlab.us/p/955539a31b0c7be330933414edd8d4af54f7dbec"
     badges: Available, Functional, Reproduced
     summary: cornflakes
     doi: "10.1145/3600006.3613137"
 
   - title: "Ditto: An Elastic and Adaptive Memory-Disaggregated Caching System"
-    github_url: "https://github.com/dmemsys/Ditto"
+    repository_url: "https://github.com/dmemsys/Ditto"
     badges: Available, Functional, Reproduced
     summary: ditto
     doi: "10.1145/3600006.3613144"
 
   - title: "Edna: Disguising and Revealing User Data in Web Applications"
-    github_url: "https://github.com/tslilyai/edna/tree/artifact"
+    repository_url: "https://github.com/tslilyai/edna/tree/artifact"
     badges: Available, Functional, Reproduced
     summary: edna
     doi: "10.1145/3600006.3613146"
 
   - title: "Efficient Memory Management for Large Language Model Serving with PagedAttention"
-    github_url: "https://github.com/sosp-ae-39/sosp-ae-astra"
+    repository_url: "https://github.com/sosp-ae-39/sosp-ae-astra"
     badges: Available, Functional, Reproduced
     summary: astra
     doi: "10.1145/3600006.3613165"
 
   - title: "Enabling High-Performance and Secure Userspace NVM File Systems with the Trio Architecture"
-    github_url: "https://github.com/vmexit/trio-sosp23-ae"
+    repository_url: "https://github.com/vmexit/trio-sosp23-ae"
     badges: Available, Functional, Reproduced
     summary: trio
     doi: "10.1145/3600006.3613171"
 
   - title: "Falcon: Fast OLTP Engine for Persistent Cache and Non-Volatile Memory"
-    github_url: "https://github.com/madsys-dev/Falcon"
+    repository_url: "https://github.com/madsys-dev/Falcon"
     badges: Available, Functional, Reproduced
     summary: falcon
     doi: "10.1145/3600006.3613141"
 
   - title: "FIFO Queues are All You Need for Cache Eviction"
-    github_url: "https://github.com/Thesys-lab/sosp23-s3fifo"
+    repository_url: "https://github.com/Thesys-lab/sosp23-s3fifo"
     badges: Available, Functional, Reproduced
     summary: fifo
     doi: "10.1145/3600006.3613147"
 
   - title: "GEMINI: Fast Failure Recovery in Distributed Training with In-Memory Checkpoints"
-    github_url: "https://github.com/zhuangwang93/SOSP-30_AE"
+    repository_url: "https://github.com/zhuangwang93/SOSP-30_AE"
     badges: Available, Functional, Reproduced
     summary: gemini
     doi: "10.1145/3600006.3613145"
 
   - title: "Grove: a Separation-Logic Library for Verifying Distributed Systems"
-    github_url: "https://github.com/mit-pdos/grove-artifact"
+    repository_url: "https://github.com/mit-pdos/grove-artifact"
     badges: Available, Functional, Reproduced
     summary: grove
     doi: "10.1145/3600006.3613172"
 
   - title: "gSampler: General and Efficient GPU-based Graph Sampling for Graph Learning"
-    github_url: "https://github.com/gpzlx1/gsampler-artifact-evaluation"
+    repository_url: "https://github.com/gpzlx1/gsampler-artifact-evaluation"
     badges: Available, Functional, Reproduced
     summary: gsampler
     doi: "10.1145/3600006.3613168"
 
   - title: "Halfmoon: Log-Optimal Fault-Tolerant Stateful Serverless Computing"
-    github_url: "https://github.com/pkusys/Halfmoon-bench"
+    repository_url: "https://github.com/pkusys/Halfmoon-bench"
     badges: Available, Functional, Reproduced
     summary: halfmoon
     doi: "10.1145/3600006.3613154"
 
   - title: "Mira: A Program-Behavior-Guided Far Memory System"
-    github_url: "https://bitbucket.org/mira-sosp23/mira-ae"
+    repository_url: "https://bitbucket.org/mira-sosp23/mira-ae"
     badges: Available, Functional, Reproduced
     summary: mira
     doi: "10.1145/3600006.3613157"
 
   - title: "Oobleck: Resilient Distributed Training of Large Models Using Pipeline Templates"
-    github_url: "https://github.com/SymbioticLab/oobleck"
+    repository_url: "https://github.com/SymbioticLab/oobleck"
     badges: Available, Functional, Reproduced
     summary: oobleck
     doi: "10.1145/3600006.3613152"
 
   - title: "Paella: Low-latency Model Serving with Software-defined GPU Scheduling"
-    github_url: "https://github.com/eniac/paella/tree/sosp23_artifact"
+    repository_url: "https://github.com/eniac/paella/tree/sosp23_artifact"
     badges: Available, Functional, Reproduced
     summary: paella
     doi: "10.1145/3600006.3613163"
 
   - title: "Partial Failure Resilient Memory Management System for (CXL-based) Distributed Shared Memory"
-    github_url: "https://github.com/madsys-dev/sosp-paper19-ae"
+    repository_url: "https://github.com/madsys-dev/sosp-paper19-ae"
     badges: Available, Functional, Reproduced
     summary: partial
     doi: "10.1145/3600006.3613135"
 
   - title: "PIT: Optimization of Dynamic Sparse Deep Learning Models via Permutation Invariant Transformation"
-    github_url: "https://github.com/microsoft/SparTA/tree/pit_artifact"
+    repository_url: "https://github.com/microsoft/SparTA/tree/pit_artifact"
     badges: Available, Functional, Reproduced
     summary: pit
     doi: "10.1145/3600006.3613139"
 
   - title: "Private Web Search with Tiptoe"
-    github_url: "https://github.com/ahenzinger/tiptoe"
+    repository_url: "https://github.com/ahenzinger/tiptoe"
     badges: Available, Functional, Reproduced
     summary: tiptoe
     doi: "10.1145/3600006.3613134"
 
   - title: "Sia: Heterogeneity-Aware, Goodput-Optimized ML-Cluster Scheduling"
-    github_url: "https://github.com/siasosp23/artifacts/tree/main"
+    repository_url: "https://github.com/siasosp23/artifacts/tree/main"
     badges: Available, Functional, Reproduced
     summary: sia
     doi: "10.1145/3600006.3613175"
 
   - title: "Snowcat: Efficient Kernel Concurrency Testing using a Learned Coverage Predictor"
-    github_url: "https://github.com/rssys/snowcat"
+    repository_url: "https://github.com/rssys/snowcat"
     badges: Available, Functional, Reproduced
     summary: snowcat
     doi: "10.1145/3600006.3613148"
 
   - title: "SPFresh: Incremental In-Place Update for Billion-Scale Vector Search"
-    github_url: "https://github.com/SPFresh/SPFresh"
+    repository_url: "https://github.com/SPFresh/SPFresh"
     badges: Available, Functional, Reproduced
     summary: spfresh
     doi: "10.1145/3600006.3613166"
 
   - title: "Turbo: Effective Caching in Differentially-Private Databases"
-    github_url: "https://github.com/columbia/turbo-artifact"
+    repository_url: "https://github.com/columbia/turbo-artifact"
     badges: Available, Functional, Reproduced
     summary: turbo
     doi: "10.1145/3600006.3613174"
 
   - title: "UGACHE: A Unified GPU Cache for Embedding-based Deep Learning"
-    github_url: "https://github.com/SJTU-IPADS/ugache-artifacts"
+    repository_url: "https://github.com/SJTU-IPADS/ugache-artifacts"
     badges: Available, Functional, Reproduced
     summary: ugache
     doi: "10.1145/3600006.3613169"
 
   - title: "Achieving Microsecond-Scale Tail Latency Efficiently with Approximate Optimal Scheduling"
-    github_url: "https://github.com/m8/concord"
+    repository_url: "https://github.com/m8/concord"
     badges: Available, Functional
     summary: concord
     doi: "10.1145/3600006.3613136"
 
   - title: "Antipode: Enforcing Cross-Service Causal Consistency in Distributed Applications"
-    github_url: "https://github.com/Antipode-SOSP23"
+    repository_url: "https://github.com/Antipode-SOSP23"
     badges: Available, Functional
     summary: antipode
     doi: "10.1145/3600006.3613176"
 
   - title: "Blueprint: A Toolchain for Highly-Reconfigurable Microservice Applications"
-    github_url: "https://gitlab.mpi-sws.org/cld/blueprint/blueprint-compiler"
+    repository_url: "https://gitlab.mpi-sws.org/cld/blueprint/blueprint-compiler"
     badges: Available, Functional
     summary: blueprint
     doi: "10.1145/3600006.3613138"
 
   - title: "MEMTIS: Efficient Memory Tiering with Dynamic Page Classification and Page Size Determination"
-    github_url: "https://github.com/cosmoss-jigu/memtis"
+    repository_url: "https://github.com/cosmoss-jigu/memtis"
     badges: Available, Functional
     summary: memtis
     doi: "10.1145/3600006.3613167"
 
   - title: "Pushing Performance Isolation Boundaries into Application with pBox"
-    github_url: "https://github.com/OrderLab/pBox"
+    repository_url: "https://github.com/OrderLab/pBox"
     badges: Available, Functional
     summary: pbox
     doi: "10.1145/3600006.3613159"
 
   - title: "QuePaxa: Escaping the tyranny of timeouts in consensus"
-    github_url: "https://github.com/dedis/quepaxa/"
+    repository_url: "https://github.com/dedis/quepaxa/"
     badges: Available, Functional
     summary: quepaxa
     doi: "10.1145/3600006.3613150"
 
   - title: "RackBlox: A Software-Defined Rack-Scale Storage System with Network-Storage Co-Design"
-    github_url: "https://github.com/breidys2/RackBlox"
+    repository_url: "https://github.com/breidys2/RackBlox"
     badges: Available, Functional
     summary: rackblox
     doi: "10.1145/3600006.3613170"
 
   - title: "Siloz: Leveraging DRAM Isolation Domains to Prevent Inter-VM Rowhammer"
-    github_url: "https://github.com/efeslab/siloz"
+    repository_url: "https://github.com/efeslab/siloz"
     badges: Available, Functional
     summary: siloz
     doi: "10.1145/3600006.3613143"
 
   - title: "Validating JIT Compilers via Compilation Space Exploration"
-    github_url: "https://doi.org/10.5281/zenodo.8188346"
+    repository_url: "https://doi.org/10.5281/zenodo.8188346"
     badges: Available, Functional
     summary: artemis
     doi: "10.1145/3600006.3613140"
@@ -257,24 +258,10 @@ artifacts:
       <td>
         {% if artifact.award %}
           <b>Distinguished&nbsp;Artifact</b><br>
-        {% endif %} {% if artifact.web_url %}
-          <a href="{{artifact.web_url}}">Web</a><br>
-        {% endif %} {% if artifact.github_url %}
-          <a href="{{artifact.github_url}}">GitHub</a><br>
-        {% endif %} {% if artifact.bitbucket_url %}
-          <a href="{{artifact.bitbucket_url}}">Bitbucket</a><br>
-        {% endif %} {% if artifact.data_url %}
-          <a href="{{artifact.data_url}}">Data</a><br>
-        {% endif %} {% if artifact.jupyter_url %}
-          <a href="{{artifact.jupyter_url}}">Jupyter&nbsp;Notebook</a><br>
-        {% endif %} {% if artifact.proof_url %}
-          <a href="{{artifact.proof_url}}">Proofs</a><br>
-        {% endif %} {% if artifact.vm_url %}
-          <a href="{{artifact.vm_url}}">VM&nbsp;Image</a><br>
+        {% endif %} {% if artifact.repository_url %}
+          <a href="{{artifact.repository_url}}">GitHub</a><br>
         {% endif %} {% if artifact.cloudlab_url %}
           <a href="{{artifact.cloudlab_url}}">CloudLab&nbsp;Profile</a><br>
-        {% endif %} {% if artifact.scripts_url %}
-          <a href="{{artifact.scripts_url}}">Scripts</a><br>
         {% endif %} {% if artifact.additional_urls %}
           {% for url in artifact.additional_urls %}
             <a href="{{url}}">Additional&nbsp;Resources</a><br>


### PR DESCRIPTION
Initial results pages of OSDI and ATC are based on markdown tables. These tables are inherently hard to parse with code. 

This PR changes the format from markdown to yaml + code to generating the tables. This allows tooling to automatically scan this repository for the information in the result pages. The suggested yaml format is relatively simple:
```
artifacts:
  - title: "title"
    doi: "paper DOI"
    badges: "list of badges, e.g., available, functional, reproducible"
    repository_url: "url to git repo"
    artifact_url: "url/doi to artifact in long-term storage"
    award: "name of the award"
```

SOSP21-23/SC21 has followed a more complex format with several different repository, github, bitbucket, gitlab, zenodo, scripts, data and other URLs. I've simplified the format to match the repository/artifact_url from above and allow additional_urls to link to an arbitrary list of URLs. This allows to keep all the additional links. 

The hope is that all current year result pages include the yaml format which leads to future artifact evaluations to adopt the format. Ideally, the maintainers ensure that the format doesn't change to drastically without good reason. This allows to keep the data minable. 