### PR TITLE
Aligning Results.md page template with the more recent one

### DIFF
--- a/_conferences/eurosys2021/results.md
+++ b/_conferences/eurosys2021/results.md
@@ -1,247 +1,183 @@
 ---
 title: Results
 order: 40
+available_img: "acm_available_1.1.png"
+available_name: "Artifacts Available (v1.1)"
+functional_img: "acm_functional_1.1.png"
+functional_name: "Artifacts Evaluated - Functional (v1.1)"
+reproduced_img: "acm_reproduced_1.1.png"
+reproduced_name: "Results Reproduced (v1.1)"
+
+artifacts:
+
+  - title: "Accelerating Graph Sampling for Graph Machine Learning using GPUs"
+    badges: "available,functional,reproduced"
+    paper_url: "10.1145/3447786.3456244"
+    repository_url: "https://github.com/abhijangda/nextdoor-experiments/"
+    second_repository_url: "https://github.com/plasma-umass/NextDoor"
+
+  - title: "Achieving Low Tail-latency and High Scalability for Serializable Transactions in Edge Computing"
+    badges: "available,functional,reproduced"
+    paper_url: "10.1145/3447786.3456238"
+    repository_url: "https://github.com/hku-systems/dast"
+
+  - title: "Characterizing, Exploiting, and Detecting DMA Code Injection Vulnerabilities in the Presence of an IOMMU"
+    badges: "available,functional,reproduced"
+    paper_url: "10.1145/3447786.3456249"
+    repository_url: "https://github.com/Markuze/mmo-static"
+    second_repository_url: "https://github.com/Markuze/dma-kasan"
+
+  - title: "DGCL: An Efficient Communication Library for Distributed GNN Training"
+    badges: "available,functional,reproduced"
+    paper_url: "10.1145/3447786.3456233"
+    repository_url: "https://github.com/czkkkkkk/gccl"
+    second_repository_url: "https://github.com/czkkkkkk/ragdoll"
+
+  - title: "M3: End-to-End Memory Management in Elastic System Software Stacks"
+    badges: "available,functional,reproduced"
+    paper_url: "10.1145/3447786.3456256"
+    repository_url: "https://github.com/dsrg-uoft"
+
+  - title: "Finding Heterogeneous-Unsafe Configuration Parameters in Cloud Systems"
+    badges: "available,functional,reproduced"
+    paper_url: "10.1145/3447786.3456250"
+    repository_url: "https://github.com/StarThinking/ZebraConf"
+
+  - title: "Home, SafeHome: Smart Home Reliability with Visibility and Atomicity"
+    badges: "available,functional,reproduced"
+    paper_url: "10.1145/3447786.3456261"
+    repository_url: "https://github.com/Shegufta/SafeHomeFramework"
+
+  - title: "PaSh: Light-touch Data-Parallel Shell Processing"
+    badges: "available,functional,reproduced"
+    paper_url: "10.1145/3447786.3456228"
+    repository_url: "https://github.com/andromeda/pash"
+
+  - title: "rkt-io: A Direct I/O Stack for Shielded Execution"
+    badges: "available,functional,reproduced"
+    paper_url: "10.1145/3447786.3456255"
+    repository_url: "https://github.com/Mic92/rkt-io"
+
+  - title: "Seastar: Vertex-Centric Programming for Graph Neural Networks"
+    badges: "available,functional,reproduced"
+    paper_url: "10.1145/3447786.3456247"
+    repository_url: "https://zenodo.org/records/4988602"
+
+  - title: "Site-to-Site Internet Traffic Control"
+    badges: "available,functional,reproduced"
+    award: "Best Artifact Award"
+    paper_url: "10.1145/3447786.3456260"
+    repository_url: "https://github.com/bundler-project/evaluation"
+
+  - title: "Tahoe: Tree Structure-Aware High Performance Inference Engine for Decision Tree Ensemble on GPU"
+    badges: "available,functional,reproduced"
+    paper_url: "10.1145/3447786.3456251"
+    repository_url: "https://github.com/zhen-xie/Tahoe"
+
+  - title: "Take it to the Limit: Peak Prediction-driven Resource Overcommitment in Datacenters"
+    badges: "available,functional,reproduced"
+    paper_url: "10.1145/3447786.3456259"
+    repository_url: "https://github.com/googleinterns/cluster-resource-forecast"
+
+  - title: "Unikraft: Fast, Specialized Unikernels the Easy Way"
+    badges: "available,functional,reproduced"
+    paper_url: "10.1145/3447786.3456248"
+    repository_url: "https://github.com/unikraft/eurosys21-artifacts"
+
+  - title: "Confidential Computing for OpenPOWER"
+    badges: "available,functional"
+    paper_url: "10.1145/3447786.3456243"
+    repository_url: "https://github.com/mvle/eurosys2021_PEF_OpenPOWER"
+    second_repository_url: "https://github.com/open-power/ultravisor/wiki/How-to-build-and-run-Secure-VM-using-Ultravisor-on-a-OpenPOWER-machine"   
+
+  - title: "DZiG: Sparsity-Aware Incremental Processing of Streaming Graphs"
+    badges: "available,functional"
+    paper_url: "10.1145/3447786.3456230"
+    repository_url: "https://github.com/pdclab/graphbolt/tree/eurosys21-artifact"
+
+  - title: "OFC: An Opportunistic Caching System for FaaS Platforms"
+    badges: "available,functional"
+    paper_url: "10.1145/3447786.3456239"
+    repository_url: "https://gitlab.com/lenapster/faascache/-/tree/master/artifactEvaluation"
+
+  - title: "Understanding and Dealing with Hard Faults in Persistent Memory Systems"
+    badges: "available,functional"
+    paper_url: "10.1145/3447786.3456252"
+    repository_url: "https://github.com/OrderLab/Arthas/blob/master/artifactREADME.md"
+
+  - title: "Odyssey: The Impact of Modern Hardware on Strongly-Consistent Replication Protocols"
+    badges: "available"
+    paper_url: "10.1145/3447786.3456240"
+    repository_url: "https://github.com/vasigavr1/Odyssey"
+
+  - title: "TraceSplitter: A New Paradigm for Downscaling Traces"
+    badges: "available"
+    paper_url: "10.1145/3447786.3456262"
+    repository_url: "https://github.com/smsajal/TraceSplitter"
+
+  - title: "Zeus: Locality-aware Distributed Transactions"
+    badges: "available"
+    paper_url: "10.1145/3447786.3456234"
+    repository_url: "https://github.com/ease-lab/Zeus"
+
 ---
 
-Artifact Evaluation was optional at EuroSys 2021; authors of accepted papers were given the
-opportunity to submit an artifact for the work discussed in the paper. The artifact may include
-source code, systems, configuration, datasets, models, test suites, benchmarks, and any other
-material underlying the paper’s contributions. 
+**Submissions**: 22 out of 38 (58% of accepted papers)
 
-The EuroSys 2021 Artifact Evaluation Committee (AEC) received a total of 22 artifact submissions
-(58% of the 38 accepted papers). Each submission was independently evaluated by at least 2 AEC
-members; the evaluations only included those badges requested by authors.
-At the end of the process, the AEC awarded a total of 21 Artifacts Available badges, 18
-Artifacts Functional badges, and 14 Results Reproduced badges, as detailed below.
+**Evaluation Results**:
 
-
-List of papers with awarded badges
-----------------------------------
+* 21 Artifact Available
+* 18 Artifact Functional
+* 14 Results Reproduced
 
 <table>
-<tr>
-  <td nowrap style="width:210px">
-    <img style="width:60px; height:60px" src="{{ site.baseurl }}/images/acm_available_1.1.png" alt="Artifacts Available badge">
-    <img style="width:60px; height:60px" src="{{ site.baseurl }}/images/acm_functional_1.1.png" alt="Artifacts Functional badge">
-    <img style="width:60px; height:60px" src="{{ site.baseurl }}/images/acm_reproduced_1.1.png" alt="Results Reproduced badge">
-  </td>
-  <td>
-    Accelerating Graph Sampling for Graph Machine Learning using GPUs<br>
-    <a href="https://github.com/plasma-umass/NextDoor">https://github.com/plasma-umass/NextDoor</a> and
-    <a href="https://github.com/abhijangda/nextdoor-experiments/">https://github.com/abhijangda/nextdoor-experiments/</a>
-  </td>
-</tr>
-<tr>
-  <td nowrap>
-    <img style="width:60px; height:60px" src="{{ site.baseurl }}/images/acm_available_1.1.png" alt="Artifacts Available badge">
-    <img style="width:60px; height:60px" src="{{ site.baseurl }}/images/acm_functional_1.1.png" alt="Artifacts Functional badge">
-    <img style="width:60px; height:60px" src="{{ site.baseurl }}/images/acm_reproduced_1.1.png" alt="Results Reproduced badge">
-  </td>
-  <td>
-    Achieving Low Tail-latency and High Scalability for Serializable Transactions in Edge Computing<br>
-    <a href="https://github.com/hku-systems/dast">https://github.com/hku-systems/dast</a>
-  </td>
-</tr>
-<tr>
-  <td nowrap>
-    <img style="width:60px; height:60px" src="{{ site.baseurl }}/images/acm_available_1.1.png" alt="Artifacts Available badge">
-    <img style="width:60px; height:60px" src="{{ site.baseurl }}/images/acm_functional_1.1.png" alt="Artifacts Functional badge">
-    <img style="width:60px; height:60px" src="{{ site.baseurl }}/images/acm_reproduced_1.1.png" alt="Results Reproduced badge">
-  </td>
-  <td>
-    Characterizing, Exploiting, and Detecting DMA Code Injection Vulnerabilities in the Presence of an IOMMU<br>
-    <a href="https://github.com/Markuze/mmo-static">https://github.com/Markuze/mmo-static</a> and
-    <a href="https://github.com/Markuze/dma-kasan">https://github.com/Markuze/dma-kasan</a>
-  </td>
-</tr>
-<tr>
-  <td nowrap>
-    <img style="width:60px; height:60px" src="{{ site.baseurl }}/images/acm_available_1.1.png" alt="Artifacts Available badge">
-    <img style="width:60px; height:60px" src="{{ site.baseurl }}/images/acm_functional_1.1.png" alt="Artifacts Functional badge">
-    <img style="width:60px; height:60px" src="{{ site.baseurl }}/images/acm_reproduced_1.1.png" alt="Results Reproduced badge">
-  </td>
-  <td>
-    DGCL: An Efficient Communication Library for Distributed GNN Training<br>
-    <a href="https://github.com/czkkkkkk/gccl">https://github.com/czkkkkkk/gccl</a> and
-    <a href="https://github.com/czkkkkkk/ragdoll">https://github.com/czkkkkkk/ragdoll</a>
-  </td>
-</tr>
-<tr>
-  <td nowrap>
-    <img style="width:60px; height:60px" src="{{ site.baseurl }}/images/acm_available_1.1.png" alt="Artifacts Available badge">
-    <img style="width:60px; height:60px" src="{{ site.baseurl }}/images/acm_functional_1.1.png" alt="Artifacts Functional badge">
-    <img style="width:60px; height:60px" src="{{ site.baseurl }}/images/acm_reproduced_1.1.png" alt="Results Reproduced badge">
-  </td>
-  <td>
-    End-to-End Memory Management in Elastic System Software Stacks<br>
-    <a href="https://github.com/dsrg-uoft">https://github.com/dsrg-uoft</a>
-  </td>
-</tr>
-<tr>
-  <td nowrap>
-    <img style="width:60px; height:60px" src="{{ site.baseurl }}/images/acm_available_1.1.png" alt="Artifacts Available badge">
-    <img style="width:60px; height:60px" src="{{ site.baseurl }}/images/acm_functional_1.1.png" alt="Artifacts Functional badge">
-    <img style="width:60px; height:60px" src="{{ site.baseurl }}/images/acm_reproduced_1.1.png" alt="Results Reproduced badge">
-  </td>
-  <td>
-    Finding Heterogeneous-Unsafe Configuration Parameters in Cloud Systems<br>
-    <a href="https://github.com/StarThinking/ZebraConf">https://github.com/StarThinking/ZebraConf</a>
-  </td>
-</tr>
-<tr>
-  <td nowrap>
-    <img style="width:60px; height:60px" src="{{ site.baseurl }}/images/acm_available_1.1.png" alt="Artifacts Available badge">
-    <img style="width:60px; height:60px" src="{{ site.baseurl }}/images/acm_functional_1.1.png" alt="Artifacts Functional badge">
-    <img style="width:60px; height:60px" src="{{ site.baseurl }}/images/acm_reproduced_1.1.png" alt="Results Reproduced badge">
-  </td>
-  <td>
-    Home, SafeHome: Smart Home Reliability with Visibility and Atomicity<br>
-    <a href="https://github.com/Shegufta/SafeHomeFramework">https://github.com/Shegufta/SafeHomeFramework</a>
-  </td>
-</tr>
-<tr>
-  <td nowrap>
-    <img style="width:60px; height:60px" src="{{ site.baseurl }}/images/acm_available_1.1.png" alt="Artifacts Available badge">
-    <img style="width:60px; height:60px" src="{{ site.baseurl }}/images/acm_functional_1.1.png" alt="Artifacts Functional badge">
-    <img style="width:60px; height:60px" src="{{ site.baseurl }}/images/acm_reproduced_1.1.png" alt="Results Reproduced badge">
-  </td>
-  <td>
-    Light-touch Data-Parallel Shell Processing<br>
-    <a href="https://github.com/andromeda/pash">https://github.com/andromeda/pash</a>
-  </td>
-</tr>
-<tr>
-  <td nowrap>
-    <img style="width:60px; height:60px" src="{{ site.baseurl }}/images/acm_available_1.1.png" alt="Artifacts Available badge">
-    <img style="width:60px; height:60px" src="{{ site.baseurl }}/images/acm_functional_1.1.png" alt="Artifacts Functional badge">
-    <img style="width:60px; height:60px" src="{{ site.baseurl }}/images/acm_reproduced_1.1.png" alt="Results Reproduced badge">
-  </td>
-  <td>
-    rkt-io: A Direct I/O Stack for Shielded Execution<br>
-    <a href="https://github.com/Mic92/rkt-io">https://github.com/Mic92/rkt-io</a>
-  </td>
-</tr>
-<tr>
-  <td nowrap>
-    <img style="width:60px; height:60px" src="{{ site.baseurl }}/images/acm_available_1.1.png" alt="Artifacts Available badge">
-    <img style="width:60px; height:60px" src="{{ site.baseurl }}/images/acm_functional_1.1.png" alt="Artifacts Functional badge">
-    <img style="width:60px; height:60px" src="{{ site.baseurl }}/images/acm_reproduced_1.1.png" alt="Results Reproduced badge">
-  </td>
-  <td>
-    Seastar: Vertex-Centric Programming for Graph Neural Networks<br>
-    <a href="https://zenodo.org/record/4988602">https://zenodo.org/record/4988602</a>
-  </td>
-</tr>
-<tr>
-  <td nowrap>
-    <img style="width:60px; height:60px" src="{{ site.baseurl }}/images/acm_available_1.1.png" alt="Artifacts Available badge">
-    <img style="width:60px; height:60px" src="{{ site.baseurl }}/images/acm_functional_1.1.png" alt="Artifacts Functional badge">
-    <img style="width:60px; height:60px" src="{{ site.baseurl }}/images/acm_reproduced_1.1.png" alt="Results Reproduced badge">
-  </td>
-  <td>
-    Site-to-Site Internet Traffic Control<br>
-    <a href="https://github.com/bundler-project/evaluation">https://github.com/bundler-project/evaluation</a>
-  </td>
-</tr>
-<tr>
-  <td nowrap>
-    <img style="width:60px; height:60px" src="{{ site.baseurl }}/images/acm_available_1.1.png" alt="Artifacts Available badge">
-    <img style="width:60px; height:60px" src="{{ site.baseurl }}/images/acm_functional_1.1.png" alt="Artifacts Functional badge">
-    <img style="width:60px; height:60px" src="{{ site.baseurl }}/images/acm_reproduced_1.1.png" alt="Results Reproduced badge">
-  </td>
-  <td>
-    Tahoe: Tree Structure-Aware High Performance Inference Engine for Decision Tree Ensemble on GPU<br>
-    <a href="https://github.com/zhen-xie/Tahoe">https://github.com/zhen-xie/Tahoe</a>
-  </td>
-</tr>
-<tr>
-  <td nowrap>
-    <img style="width:60px; height:60px" src="{{ site.baseurl }}/images/acm_available_1.1.png" alt="Artifacts Available badge">
-    <img style="width:60px; height:60px" src="{{ site.baseurl }}/images/acm_functional_1.1.png" alt="Artifacts Functional badge">
-    <img style="width:60px; height:60px" src="{{ site.baseurl }}/images/acm_reproduced_1.1.png" alt="Results Reproduced badge">
-  </td>
-  <td>
-    Take it to the Limit: Peak Prediction-driven Resource Overcommitment in Datacenters<br>
-    <a href="https://github.com/googleinterns/cluster-resource-forecast">https://github.com/googleinterns/cluster-resource-forecast</a>
-  </td>
-</tr>
-<tr>
-  <td nowrap>
-    <img style="width:60px; height:60px" src="{{ site.baseurl }}/images/acm_available_1.1.png" alt="Artifacts Available badge">
-    <img style="width:60px; height:60px" src="{{ site.baseurl }}/images/acm_functional_1.1.png" alt="Artifacts Functional badge">
-    <img style="width:60px; height:60px" src="{{ site.baseurl }}/images/acm_reproduced_1.1.png" alt="Results Reproduced badge">
-  </td>
-  <td>
-    Unikraft: Fast, Specialized Unikernels the Easy Way<br>
-    <a href="https://github.com/unikraft/eurosys21-artifacts">https://github.com/unikraft/eurosys21-artifacts</a>
-  </td>
-</tr>
-<tr>
-  <td nowrap>
-    <img style="width:60px; height:60px" src="{{ site.baseurl }}/images/acm_available_1.1.png" alt="Artifacts Available badge">
-    <img style="width:60px; height:60px" src="{{ site.baseurl }}/images/acm_functional_1.1.png" alt="Artifacts Functional badge">
-  </td>
-  <td>
-    Confidential Computing for OpenPOWER<br>
-    <a href="https://github.com/mvle/eurosys2021_PEF_OpenPOWER">https://github.com/mvle/eurosys2021_PEF_OpenPOWER</a> and
-    <a href="https://github.com/open-power/ultravisor/wiki/How-to-build-and-run-Secure-VM-using-Ultravisor-on-a-OpenPOWER-machine">https://github.com/open-power/ultravisor/wiki/How-to-build-and-run-Secure-VM-using-Ultravisor-on-a-OpenPOWER-machine</a>
-  </td>
-</tr>
-<tr>
-  <td nowrap>
-    <img style="width:60px; height:60px" src="{{ site.baseurl }}/images/acm_available_1.1.png" alt="Artifacts Available badge">
-    <img style="width:60px; height:60px" src="{{ site.baseurl }}/images/acm_functional_1.1.png" alt="Artifacts Functional badge">
-  </td>
-  <td>
-    DZiG: Sparsity-Aware Incremental Processing of Streaming Graphs<br>
-    <a href="https://github.com/pdclab/graphbolt/tree/eurosys21-artifact">https://github.com/pdclab/graphbolt/tree/eurosys21-artifact</a>
-  </td>
-</tr>
-<tr>
-  <td nowrap>
-    <img style="width:60px; height:60px" src="{{ site.baseurl }}/images/acm_available_1.1.png" alt="Artifacts Available badge">
-    <img style="width:60px; height:60px" src="{{ site.baseurl }}/images/acm_functional_1.1.png" alt="Artifacts Functional badge">
-  </td>
-  <td>
-    OFC: An Opportunistic Caching System for FaaS Platforms<br>
-    <a href="https://gitlab.com/lenapster/faascache/-/tree/master/artifactEvaluation">https://gitlab.com/lenapster/faascache/-/tree/master/artifactEvaluation</a>
-  </td>
-</tr>
-<tr>
-  <td nowrap>
-    <img style="width:60px; height:60px" src="{{ site.baseurl }}/images/acm_available_1.1.png" alt="Artifacts Available badge">
-    <img style="width:60px; height:60px" src="{{ site.baseurl }}/images/acm_functional_1.1.png" alt="Artifacts Functional badge">
-  </td>
-  <td>
-    Understanding and Dealing with Hard Faults in Persistent Memory Systems<br>
-    <a href="https://github.com/OrderLab/Arthas/blob/master/artifactREADME.md">https://github.com/OrderLab/Arthas/blob/master/artifactREADME.md</a>
-  </td>
-</tr>
-<tr>
-  <td nowrap>
-    <img style="width:60px; height:60px" src="{{ site.baseurl }}/images/acm_available_1.1.png" alt="Artifacts Available badge">
-  </td>
-  <td>
-    Odyssey: The Impact of Modern Hardware on Strongly-Consistent Replication Protocols<br>
-    <a href="https://github.com/vasigavr1/Odyssey">https://github.com/vasigavr1/Odyssey</a>
-  </td>
-</tr>
-<tr>
-  <td nowrap>
-    <img style="width:60px; height:60px" src="{{ site.baseurl }}/images/acm_available_1.1.png" alt="Artifacts Available badge">
-  </td>
-  <td>
-    TraceSplitter: A New Paradigm for Downscaling Traces<br>
-    <a href="https://github.com/smsajal/TraceSplitter">https://github.com/smsajal/TraceSplitter</a>
-  </td>
-</tr>
-<tr>
-  <td nowrap>
-    <img style="width:60px; height:60px" src="{{ site.baseurl }}/images/acm_available_1.1.png" alt="Artifacts Available badge">
-  </td>
-  <td>
-    Zeus: Locality-aware Distributed Transactions<br>
-    <a href="https://github.com/ease-lab/Zeus">https://github.com/ease-lab/Zeus</a>
-  </td>
-</tr>
+  <thead>
+    <tr>
+      <th>Paper title</th>
+      <th>Available</th>
+      <th>Functional</th>
+      <th>Reproduced</th>
+      <th>Available At</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for artifact in page.artifacts %}
+    <tr>
+      <td>
+        {% if artifact.paper_url %}
+          <a href="https://doi.org/{{artifact.paper_url}}" target="_blank">{{artifact.title}}</a>
+        {% else %}
+          {{ artifact.title }}
+        {% endif %}
+      </td>
+      <td width="62px">
+        {% if artifact.badges contains "available" %}
+          <img src="{{ site.baseurl }}/images/{{ page.available_img }}" alt="{{ page.available_name }}" width="50px">
+        {% endif %}
+      </td>
+      <td width="62px">
+        {% if artifact.badges contains "functional" %}
+          <img src="{{ site.baseurl }}/images/{{ page.functional_img }}" alt="{{ page.functional_name }}" width="50px">
+        {% endif %}
+      </td>
+      <td width="62px">
+        {% if artifact.badges contains "reproduced" %}
+          <img src="{{ site.baseurl }}/images/{{ page.reproduced_img }}" alt="{{ page.reproduced_name }}" width="50px">
+        {% endif %}
+      </td>
+      <td>
+        {% if artifact.award %}
+          <b>{{ artifact.award }}</b><br>
+        {% endif %} {% if artifact.artifact_url %}
+          <a href="https://doi.org/{{artifact.artifact_url}}" target="_blank">Artifact</a><br>
+        {% endif %} {% if artifact.repository_url %}
+          <a href="{{artifact.repository_url}}" target="_blank">Repository</a><br>
+        {% endif %} {% if artifact.second_repository_url %}
+        and
+          <a href="{{artifact.second_repository_url}}" target="_blank">Repository</a><br>
+        {% endif %}
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
 </table>


### PR DESCRIPTION
I have rewritten the results reported on this page using the table template used for the following years. The need to have the results formatted in the same way across the years came when writing some simple scripts to automatically collect the results data and calculate some statistics across the different AE editions.

During this process I also corrected two incomplete paper names and added the information about the best artifact award which was missing before.