### PR TITLE
Update guides heading on homepage

### DIFF
--- a/index.md
+++ b/index.md
@@ -26,9 +26,8 @@ release usable software systems and validate the results of papers.
   {% endif %}
 {% endfor %}
 
-## Contribute to Sysartifacts
+## Additional Resources
 
-Additional resources for artifact evaluation:
 - [Guide for AE chairs](chair-guide.md)
 - [Guide for artifact evaluators](evaluator-guide.md)
 - [Guide for authors to package artifacts](packaging-guide.md)


### PR DESCRIPTION
Now that we have guides, we should direct people's attention to them. The previous heading made it look like most people shouldn't bother to read that section.

Credit to Vaastav for making me notice this (via email).