### PR TITLE
Add FAST '24 and FAST '25 artifact evaluation results

### DIFF
--- a/_conferences/fast2024/organizers.md
+++ b/_conferences/fast2024/organizers.md
@@ -9,3 +9,35 @@ order: 20
 [Huaicheng Li](https://huaicheng.github.io), Virginia Tech <br>
 
 ## Artifact Evaluation Committee
+
+Saheed Olayemi Bolarinwa, The Leibniz Supercomputing Centre<br>
+Chunfeng Du, Xiamen University<br>
+Jian Gao, Tsinghua University<br>
+Andrzej Jackowski, University of Warsaw<br>
+Chenhao Jiang, University of Toronto<br>
+Ziyang Jiao, Syracuse University<br>
+R. Madhava Krishnan, Oracle<br>
+Jiamin Li, City University of Hong Kong<br>
+Xiaolu Li, Huazhong University of Science and Technology<br>
+Congyu Liu, Purdue University<br>
+Ruiming Lu, Shanghai Jiao Tong University<br>
+Teng Ma, Alibaba Group<br>
+Weiwu Pang, University of Southern California<br>
+Marcus Paradies, Technische Universität Ilmenau<br>
+Bo Peng, Shanghai Jiao Tong University<br>
+Benjamin Reidys, University of Illinois at Urbana–Champaign<br>
+Reza Salkhordeh, Johannes Gutenberg University<br>
+Tomoya Suzuki, University of California, San Diego<br>
+Dingwen Tao, Indiana University<br>
+Lingfeng Xiang, The University of Texas at Arlington<br>
+Danning Xie, Purdue University<br>
+Minhui Xie, Tsinghua University<br>
+Chenhao Ye, University of Wisconsin—Madison<br>
+Liangcheng Yu, University of Pennsylvania<br>
+Anlan Zhang, University of Southern California<br>
+Jianshun Zhang, Huazhong University of Science and Technology<br>
+Xuechen Zhang, Washington State University Vancouver<br>
+Mai Zheng, Iowa State University<br>
+Shawn Zhong, University of Wisconsin—Madison<br>
+Yuqing Zhu, Tsinghua University<br>
+Xiangyu Zou, Harbin Institute of Technology Shenzhen

--- a/_conferences/fast2024/results.md
+++ b/_conferences/fast2024/results.md
@@ -1,0 +1,124 @@
+---
+title: Results
+order: 50
+available_img: "usenix_available.svg"
+available_name: "Artifacts Available"
+functional_img: "usenix_functional.svg"
+functional_name: "Artifacts Evaluated - Functional"
+reproduced_img: "usenix_reproduced.svg"
+reproduced_name: "Results Reproduced"
+
+artifacts:
+  - title: "RFUSE: Modernizing Userspace Filesystem Framework through Scalable Kernel-Userspace Communication"
+    paper_url: "https://www.usenix.org/system/files/fast24-cho.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "The Design and Implementation of a Capacity-Variant Storage System"
+    paper_url: "https://www.usenix.org/system/files/fast24-jiao.pdf"
+    badges: "available,functional"
+
+  - title: "I/O Passthru: Upstreaming a flexible and efficient I/O Path in Linux"
+    paper_url: "https://www.usenix.org/system/files/fast24-joshi.pdf"
+    badges: "available,functional"
+
+  - title: "Symbiosis: The Art of Application and Kernel Cache Cooperation"
+    paper_url: "https://www.usenix.org/system/files/fast24-dai.pdf"
+    badges: "available,functional"
+
+  - title: "We Ain't Afraid of No File Fragmentation: Causes and Prevention of Its Performance Impact on Modern Flash SSDs"
+    paper_url: "https://www.usenix.org/system/files/fast24-jun.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "Physical vs. Logical Indexing with IDEA: Inverted Deduplication-Aware Index"
+    paper_url: "https://www.usenix.org/system/files/fast24-levi.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "MinFlow: High-performance and Cost-efficient Data Passing for I/O-intensive Stateful Serverless Analytics"
+    paper_url: "https://www.usenix.org/system/files/fast24-li.pdf"
+    badges: "available"
+
+  - title: "Metis: File System Model Checking via Versatile Input and State Exploration"
+    paper_url: "https://www.usenix.org/system/files/fast24-liu-yifei.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "MIDAS: Minimizing Write Amplification in Log-Structured Systems through Adaptive Group Number and Size Configuration"
+    paper_url: "https://www.usenix.org/system/files/fast24-oh.pdf"
+    badges: "available,functional"
+
+  - title: "Combining Buffered I/O and Direct I/O in Distributed File Systems"
+    paper_url: "https://www.usenix.org/system/files/fast24-qian.pdf"
+    badges: "available"
+
+  - title: "ELECT: Enabling Erasure Coding Tiering for LSM-tree-based Storage"
+    paper_url: "https://www.usenix.org/system/files/fast24-ren.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "Kosmo: Efficient Online Miss Ratio Curve Generation for Eviction Policy Evaluation"
+    paper_url: "https://www.usenix.org/system/files/fast24-shakiba.pdf"
+    badges: "available,functional"
+
+  - title: "Baleen: ML Admission & Prefetching for Flash Caches"
+    paper_url: "https://www.usenix.org/system/files/fast24-wong.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "TeRM: Extending RDMA-Attached Memory with SSD"
+    paper_url: "https://www.usenix.org/system/files/fast24-yang-zhe.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "COLE: A Column-based Learned Storage for Blockchain Systems"
+    paper_url: "https://www.usenix.org/system/files/fast24-zhang_ce.pdf"
+    badges: "available,functional"
+
+  - title: "OmniCache: Collaborative Caching for Near-storage Accelerators"
+    paper_url: "https://www.usenix.org/system/files/fast24-zhang-jian.pdf"
+    badges: "available,functional"
+
+  - title: "In-Memory Key-Value Store Live Migration with NetMigrate"
+    paper_url: "https://www.usenix.org/system/files/fast24-zhu.pdf"
+    badges: "available,functional,reproduced"
+---
+
+**Evaluation Results**:
+
+* 17 Artifacts Available
+* 15 Artifacts Functional
+* 8 Results Reproduced
+
+<table>
+  <thead>
+    <tr>
+      <th>Paper title</th>
+      <th>Avail.</th>
+      <th>Funct.</th>
+      <th>Repro.</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for artifact in page.artifacts %}
+    <tr>
+      <td>
+        {% if artifact.paper_url %}
+          <a href="{{artifact.paper_url}}" target="_blank">{{artifact.title}}</a>
+        {% else %}
+          {{ artifact.title }}
+        {% endif %}
+      </td>
+      <td>
+        {% if artifact.badges contains "available" %}
+          <img src="{{ site.baseurl }}/images/{{ page.available_img }}" alt="{{ page.available_name }}" width="50px">
+        {% endif %}
+      </td>
+      <td>
+        {% if artifact.badges contains "functional" %}
+          <img src="{{ site.baseurl }}/images/{{ page.functional_img }}" alt="{{ page.functional_name }}" width="50px">
+        {% endif %}
+      </td>
+      <td>
+        {% if artifact.badges contains "reproduced" %}
+          <img src="{{ site.baseurl }}/images/{{ page.reproduced_img }}" alt="{{ page.reproduced_name }}" width="50px">
+        {% endif %}
+      </td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>

--- a/_conferences/fast2025/organizers.md
+++ b/_conferences/fast2025/organizers.md
@@ -9,3 +9,58 @@ order: 20
 [Juncheng Yang](https://junchengyang.com), Harvard University <br>
 
 ## Artifact Evaluation Committee
+
+Ghadeer Almusaddar, Binghamton University<br>
+Benixon Arul dhas, Samsung<br>
+Sanjith Athlur, Carnegie Mellon University<br>
+Rahul Bhadani, The University of Alabama in Huntsville<br>
+Zhang Cao, Xidian University<br>
+Yiwei Chen, Carnegie Mellon University<br>
+Tejas Chopra, Netflix<br>
+Ismet Dagli, Colorado School of Mines<br>
+Omkar Desai, Syracuse University<br>
+Ruwen Fan, Tsinghua University<br>
+Haoyu Gong, University of Minnesota Twin Cities<br>
+Pradeep Kumar Goudagunta, Dropbox<br>
+Kiran Shashi Hombal, University of Illinois at Urbana–Champaign<br>
+Guangyu Hu, The Hong Kong University of Science and Technology<br>
+Guanzhou Hu, University of Wisconsin—Madison<br>
+Lei Huang, Boston University<br>
+Lokesh Nagappa Jaliminche, University of California, Santa Cruz<br>
+Priyanka Jayaswal, Microsoft<br>
+Minhao Jin, Princeton University<br>
+Ying Jing, University of Illinois at Urbana–Champaign<br>
+Konstantinos Kanellis, University of Wisconsin—Madison<br>
+Zhaokang Ke, University of Minnesota Twin Cities<br>
+Jiajun Li, Carnegie Mellon University<br>
+Yi Liu, University of California, Santa Cruz<br>
+Ruiming Lu, Shanghai Jiao Tong University<br>
+Kabilan Mahathevan, National University of Singapore<br>
+Ziming Mao, University of California, Berkeley<br>
+Utkarsh Mittal, BCS, IEEE, and Gap<br>
+Hojin Park, Carnegie Mellon University<br>
+Rohan Puri, Samsung<br>
+Hariharan Ragothaman, Athenahealth and Northeastern University<br>
+Sriram Rangarajan, Netflix<br>
+Alok Ranjan, Carnegie Mellon University<br>
+Harisankar Sadasivan, AMD<br>
+Kartik Sathyanarayanan, Netflix<br>
+Souptik Sen, Snowflake<br>
+Dongjoo Seo, University of California, Irvine<br>
+Aakash Sharma, UiT The Arctic University of Norway<br>
+Shubhendra Pal Singhal, Georgia Institute of Technology<br>
+Vikranth Srivatsa, University of California, San Diego<br>
+Gongjin Sun, Samsung<br>
+Yifei Sun, Northeastern University<br>
+Sarvesh Tandon, Carnegie Mellon University<br>
+Divyaank Tiwari, Stony Brook University<br>
+Qing Wang, Tsinghua University<br>
+Ron Yifeng Wang, Stanford University<br>
+Wenlong Wang, University of Minnesota Twin Cities<br>
+Amit Warke, Hitachi<br>
+Hanfei Yu, Stevens Institute of Technology<br>
+Da Zhang, Samsung<br>
+Jianshun Zhang, Huazhong University of Science and Technology<br>
+Tianru Zhang, Uppsala University<br>
+Chen Zhong, The University of Texas at Arlington<br>
+Zeying Zhu, University of Maryland, College Park

--- a/_conferences/fast2025/results.md
+++ b/_conferences/fast2025/results.md
@@ -1,0 +1,128 @@
+---
+title: Results
+order: 50
+available_img: "usenix_available.svg"
+available_name: "Artifacts Available"
+functional_img: "usenix_functional.svg"
+functional_name: "Artifacts Evaluated - Functional"
+reproduced_img: "usenix_reproduced.svg"
+reproduced_name: "Results Reproduced"
+
+artifacts:
+  - title: "LeapGNN: Accelerating Distributed GNN Training Leveraging Feature-Centric Model Migration"
+    paper_url: "https://www.usenix.org/system/files/fast25-chen-weijian-leap.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "GPHash: An Efficient Hash Index for GPU with Byte-Granularity Persistent Memory"
+    paper_url: "https://www.usenix.org/system/files/fast25-chen-menglei.pdf"
+    badges: "available"
+
+  - title: "AegonKV: A High Bandwidth, Low Tail Latency, and Low Storage Cost KV-Separated LSM Store with SmartSSD-based GC Offloading"
+    paper_url: "https://www.usenix.org/system/files/fast25-duan.pdf"
+    badges: "available,functional"
+
+  - title: "Revisiting Network Coding for Warm Blob Storage"
+    paper_url: "https://www.usenix.org/system/files/fast25-gan.pdf"
+    badges: "available"
+
+  - title: "ShiftLock: Mitigate One-sided RDMA Lock Contention via Handover"
+    paper_url: "https://www.usenix.org/system/files/fast25-gao.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "Silhouette: Leveraging Consistency Mechanisms to Detect Bugs in Persistent Memory-Based File Systems"
+    paper_url: "https://www.usenix.org/system/files/fast25-jiao.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "OPIMQ: Order Preserving IO stack for Multi-Queue Block Device"
+    paper_url: "https://www.usenix.org/system/files/fast25-kim-jieun.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "D2FS: Device-Driven Filesystem Garbage Collection"
+    paper_url: "https://www.usenix.org/system/files/fast25-kim-juwon.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "Selective On-Device Execution of Data-Dependent Read I/Os"
+    paper_url: "https://www.usenix.org/system/files/fast25-park.pdf"
+    badges: "available,functional"
+
+  - title: "Don't Maintain Twice, It's Alright: Merged Metadata Management in Deduplication File System with GogetaFS"
+    paper_url: "https://www.usenix.org/system/files/fast25-pan.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "PolyStore: Exploiting Combined Capabilities of Heterogeneous Storage"
+    paper_url: "https://www.usenix.org/system/files/fast25-ren.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "Cloudscape: A Study of Storage Services in Modern Cloud Architectures"
+    paper_url: "https://www.usenix.org/system/files/fast25-satija.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "VectorCDC: Accelerating Data Deduplication with Vector Instructions"
+    paper_url: "https://www.usenix.org/system/files/fast25-udayashankar.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "Boosting File Systems Elegantly: A Transparent NVM Write-ahead Log for Disk File Systems"
+    paper_url: "https://www.usenix.org/system/files/fast25-wang.pdf"
+    badges: "available,functional"
+
+  - title: "Oasis: An Out-of-core Approximate Graph System via All-Distances Sketches"
+    paper_url: "https://www.usenix.org/system/files/fast25-yang.pdf"
+    badges: "available"
+
+  - title: "Rethinking the Request-to-IO Transformation Process of File Systems for Full Utilization of High-Bandwidth SSDs"
+    paper_url: "https://www.usenix.org/system/files/fast25-zhan.pdf"
+    badges: "available"
+
+  - title: "3L-Cache: Low Overhead and Precise Learning-based Eviction Policy for Caches"
+    paper_url: "https://www.usenix.org/system/files/fast25-zhou-wenbin.pdf"
+    badges: "available,functional"
+
+  - title: "HiDPU: A DPU-Oriented Hybrid Indexing Scheme for Disaggregated Storage Systems"
+    paper_url: "https://www.usenix.org/system/files/fast25-zhu.pdf"
+    badges: "available,functional"
+---
+
+**Evaluation Results**:
+
+* 18 Artifacts Available
+* 14 Artifacts Functional
+* 9 Results Reproduced
+
+<table>
+  <thead>
+    <tr>
+      <th>Paper title</th>
+      <th>Avail.</th>
+      <th>Funct.</th>
+      <th>Repro.</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for artifact in page.artifacts %}
+    <tr>
+      <td>
+        {% if artifact.paper_url %}
+          <a href="{{artifact.paper_url}}" target="_blank">{{artifact.title}}</a>
+        {% else %}
+          {{ artifact.title }}
+        {% endif %}
+      </td>
+      <td>
+        {% if artifact.badges contains "available" %}
+          <img src="{{ site.baseurl }}/images/{{ page.available_img }}" alt="{{ page.available_name }}" width="50px">
+        {% endif %}
+      </td>
+      <td>
+        {% if artifact.badges contains "functional" %}
+          <img src="{{ site.baseurl }}/images/{{ page.functional_img }}" alt="{{ page.functional_name }}" width="50px">
+        {% endif %}
+      </td>
+      <td>
+        {% if artifact.badges contains "reproduced" %}
+          <img src="{{ site.baseurl }}/images/{{ page.reproduced_img }}" alt="{{ page.reproduced_name }}" width="50px">
+        {% endif %}
+      </td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>


### PR DESCRIPTION
## Summary

Add `results.md` pages for **FAST 2024** and **FAST 2025** artifact evaluation results.

### FAST 2024
- **17 artifacts evaluated**: 17 Available, 15 Functional, 8 Reproduced
- Papers and badges scraped from https://www.usenix.org/conference/fast24/technical-sessions

### FAST 2025
- **18 artifacts evaluated**: 18 Available, 14 Functional, 9 Reproduced
- Papers and badges scraped from https://www.usenix.org/conference/fast25/technical-sessions

### Method

The results were generated using [`generate_results.py`](https://github.com/ReproDB/reprodb-pipeline/blob/main/src/scrapers/generate_results.py) from the [ReproDB pipeline](https://github.com/ReproDB/reprodb-pipeline), which scrapes the official USENIX conference pages for paper titles and artifact evaluation badge images:

```bash
python -m src.scrapers.generate_results --target sysartifacts --conference fast --years 2024,2025 --output_dir ./_conferences
```

Both `fast2024/` and `fast2025/` directories already existed with call-for-artifacts pages but were missing `results.md`.

### Files Changed
- `_conferences/fast24/results.md` (new)
- `_conferences/fast25/results.md` (new)