### PR TITLE
Add OSDI '25 artifact evaluation results

### DIFF
--- a/_conferences/osdi2025/organizers.md
+++ b/_conferences/osdi2025/organizers.md
@@ -1,0 +1,184 @@
+---
+title: Organizers
+order: 20
+---
+
+## Artifact Evaluation Committee Co-Chairs
+
+[Ryan Huang](https://ryanhuang.com), University of Michigan <br>
+[Tianyin Xu](https://tianyin.github.io), University of Illinois Urbana–Champaign <br>
+
+## Artifact Evaluation Committee
+
+Ghazal Abdollahi, University of Utah<br>
+Ghadeer Almusaddar, Binghamton University<br>
+Ayush Bansal, University of Illinois Urbana–Champaign<br>
+Binong Kiri Bey, Indian Institute of Technology<br>
+Archit Bhatnagar, University of Michigan<br>
+Rahul Bothra, University of Illinois Urbana–Champaign<br>
+Cláudia Brito, INESC TEC and University of Minho<br>
+Quinn Burke, University of Wisconsin–Madison<br>
+Cathy Cai, University of Illinois Urbana–Champaign<br>
+Tingjia Cao, University of Wisconsin–Madison<br>
+Sarthak Chakraborty, University of Illinois Urbana–Champaign<br>
+Hongzheng Chen, Cornell University<br>
+Qixuan Chen, Boston University<br>
+Xiang Chen, Hong Kong University of Science and Technology<br>
+Yi Chen, University of Michigan<br>
+Feng Cheng, Duke University<br>
+Georgia Christofidi, IMDEA Software Institute<br>
+Jackson Clark, University of Illinois Urbana–Champaign<br>
+Chuanqi Cong, Beihang University<br>
+Guangyang Deng, Xiamen University<br>
+Jiaqi Deng, Georgia Institute of Technology<br>
+Sriram Devata, University of Illinois Urbana–Champaign<br>
+Huibing Dong, University of Minnesota<br>
+Juechu Dong, University of Michigan<br>
+Chunfeng Du, Zhengzhou University<br>
+Enguang Fan, University of Illinois Urbana–Champaign<br>
+Yuan Feng, University of California, Merced<br>
+Shen Fu, University of Science and Technology of China<br>
+Kaihui Gao, Zhongguancun Laboratory<br>
+Xiangyu Gao, University of Washington<br>
+Raja Gond, Microsoft Research<br>
+Jinnan Guo, Imperial College London<br>
+Ke Han, Purdue University<br>
+Wanning He, University of Michigan<br>
+Kiran Hombal, University of Illinois Urbana–Champaign<br>
+Lana Honcharuk, Crusoe Cloud<br>
+Tony Hong, University of Illinois Urbana–Champaign<br>
+Guanzhou Hu, University of Wisconsin–Madison<br>
+Hao Hu, Harare Institute of Technology<br>
+Tiancheng Hu, Peking University<br>
+Hao Huang, Harbin Institute of Technology<br>
+Lei Huang, Boston University<br>
+Ryan Huang, University of Michigan<br>
+Songlin Huang, The University of Hong Kong<br>
+Yibo Huang, University of Michigan<br>
+Malvika Jadhav, University of Florida<br>
+Shashwat Jaiswal, University of Illinois Urbana–Champaign<br>
+Yuchen Ji, ShanghaiTech University<br>
+Haitian Jiang, New York University<br>
+Teng "Sebastian" Jiang, Columbia University<br>
+Zhihan Jiang, Chinese University of Hong Kong<br>
+Zewen Jin, University of Science and Technology of China<br>
+Sagar Bharadwaj Kalasibail Seetharam, Carnegie Mellon University<br>
+Rishika Varma Kalidindi, University of Michigan<br>
+Saisha Kamat, University of North Carolina at Charlotte<br>
+Ashish Kashinath, University of Illinois Urbana–Champaign<br>
+Zhaokang Ke, University of Minnesota<br>
+Jungwoo Kim, Stanford University<br>
+Arohi Kumar, Google<br>
+Fadhil Kurnia, University of Massachusetts Amherst<br>
+Borui Li, Southeast University<br>
+Hanchen Li, Stealth Startup and University of California, Berkeley<br>
+Jiansong Li, Li Auto Inc<br>
+Junzhe Li, The University of Hong Kong<br>
+Shengkai Li, University of Chinese Academy of Sciences<br>
+Sijia Li, Virginia Tech<br>
+Tuo Li, Tsinghua University<br>
+Yueying Li, Cornell University<br>
+Yuke Li, University of California, Merced<br>
+Zeyu Li, Hong Kong University of Science and Technology<br>
+Zhifei Li, University of California, Berkeley<br>
+Junxuan Liao, University of Wisconsin–Madison<br>
+Georgios Liargkovas, Columbia University<br>
+Changyuan Lin, University of British Columbia<br>
+Jing Liu, Max Planck Institute for Security and Privacy<br>
+Peizhe Liu, University of Illinois Urbana–Champaign<br>
+Yiqi Liu, University of Illinois Urbana–Champaign<br>
+Jiaheng Lu, University of Michigan<br>
+Shouxi Luo, Southwest Jiaotong University<br>
+Yilong Luo, Peking University<br>
+Jeff J. Ma, University of Michigan<br>
+Shivani Mehendarge, Amazon<br>
+Deepanjali Mishra, Carnegie Mellon University<br>
+Farzad Mohammadi, Imperial College London<br>
+Grigoris Ntousakis, Brown University<br>
+João Oliveira, INESC-ID and Instituto Superior Técnico, Universidade de Lisboa<br>
+Nikolaos Pagonas, Columbia University<br>
+Jiaqi Pan, University of Illinois Urbana–Champaign and Tsinghua University<br>
+Lichen Pan, Peking University<br>
+Melissa Z. Pan, University of California, Berkeley<br>
+Yanqi Pan, Harbin Institute of Technology<br>
+Zaifeng Pan, University of California, San Diego<br>
+Santosh Pandey, Rutgers University<br>
+Konstantinos Papaioannou, IMDEA Software Institute<br>
+Michael Paper, Stanford University<br>
+Magdalena Pasternak, University of Florida<br>
+Sibendu Paul, Amazon Prime Video<br>
+Pedro Henrique Penna, Microsoft Research<br>
+Stratos Psomadakis, National Technical University of Athens<br>
+Rohan Puri, Samsung Semiconductor<br>
+Shangshu Qian, Purdue University<br>
+Feiran (Alex) Qin, North Carolina State University<br>
+Suyan Qu, University of Wisconsin–Madison<br>
+Vishal Rao, Georgia Institute of Technology<br>
+Siddhant Ray, University of Chicago<br>
+Jonah Rosenblum, University of Michigan<br>
+Giannis Roumpos, IMDEA Software Institute<br>
+Amit Samanta, University of Utah<br>
+Srinjoy Sarkar, Indian Institute of Technology<br>
+Aditya Shah, Google<br>
+Shail Shah, Microsoft<br>
+Shazibul Islam Shamim, Kennesaw State University<br>
+Tanvi Sharma, Purdue University<br>
+Xiaoxiang Shi, Shanghai Jiao Tong University<br>
+Sachin Kumar Singh, University of Utah<br>
+Jiansen Song, Chinese Academy of Sciences<br>
+Yuhang Song, Boston University<br>
+Zihe Song, The University of Texas at Dallas<br>
+Cesar A. Stuardo, ByteDance<br>
+Yiming Su, University of Illinois Urbana–Champaign<br>
+Qingxiao Sun, China University of Petroleum<br>
+Tong Sun, Zhejiang University<br>
+Xin Tan, Chinese University of Hong Kong<br>
+Syed Salauddin Mohammad Tariq, University of Michigan<br>
+Sahil Tyagi, Oak Ridge National Laboratory<br>
+Diogo Vaz, INESC-ID and Instituto Superior Técnico, Universidade de Lisboa<br>
+Alan Wang, Northeastern University<br>
+Ruihong Wang, Purdue University<br>
+Wenlong Wang, University of Minnesota<br>
+Xinkai Wang, Shanghai Jiao Tong University<br>
+Yun Wang, Shanghai Jiao Tong University<br>
+Chiyue Wei, Duke University<br>
+Hengfeng Wei, Nanjing University<br>
+Caeden Whitaker, University of Wisconsin–Madison<br>
+Chao Wu, Nanjing University of Science and Technology<br>
+Yanran Wu, Purdue University<br>
+Zeqing Wu, Zhengzhou University<br>
+Ziqiang Wu, Huazhong University of Science and Technology<br>
+Xingyu Xiang, Harvard University<br>
+Shaokang Xie, University of California, Davis<br>
+Yifan Xie, National University of Defense Technology<br>
+Guanglei Xu, Huazhong University of Science and Technology<br>
+Hanchen Xu, Virginia Tech<br>
+Haocheng Xu, University of California, Irvine<br>
+Tianyin Xu, University of Illinois Urbana–Champaign<br>
+Kaiwen Xue, University of Michigan<br>
+Mingxuan Yang, Imperial College London<br>
+Sheng Yao, Hong Kong University of Science and Technology<br>
+Chenhao Ye, University of Wisconsin–Madison<br>
+Jia Yin, Renmin University<br>
+Jinsun Yoo, Georgia Institute of Technology<br>
+Boxi Yu, Chinese University of Hong Kong<br>
+Diman Zad Tootaghaj, Hewlett Packard Labs<br>
+Wahid Uz Zaman, The Pennsylvania State University<br>
+Ioannis Zarkadas, Columbia University<br>
+Junyao Zhang, Duke University<br>
+Siyuan Zhang, Ohio State University<br>
+Songhao Zhang, University of Illinois Urbana–Champaign<br>
+Wenhui Zhang, ByteDance<br>
+Xiangqun Zhang, Syracuse University<br>
+Xiao Zhang, The University of Texas at Austin<br>
+Yuanliang Zhang, National University of Defense Technology<br>
+Naiqian Zheng, Peking University<br>
+Xinying Zheng, University of Illinois Urbana–Champaign<br>
+Yusheng Zheng, University of California, Santa Cruz<br>
+Shawn Zhong, University of Wisconsin–Madison<br>
+Tianle Zhong, University of Virginia<br>
+Yangjie Zhou, National University of Singapore<br>
+Jianian Zhu, Huazhong University of Science and Technology<br>
+Siqi Zhu, Tsinghua University<br>
+Zeying Zhu, University of Maryland<br>
+Xiangyu Zou, Harbin Institute of Technology

--- a/_conferences/osdi2025/results.md
+++ b/_conferences/osdi2025/results.md
@@ -1,0 +1,208 @@
+---
+title: Results
+order: 50
+available_img: "usenix_available.svg"
+available_name: "Artifacts Available"
+functional_img: "usenix_functional.svg"
+functional_name: "Artifacts Evaluated - Functional"
+reproduced_img: "usenix_reproduced.svg"
+reproduced_name: "Results Reproduced"
+
+artifacts:
+  - title: "EMT: An OS Framework for New Memory Translation Architectures"
+    paper_url: "https://www.usenix.org/system/files/osdi25-chai-siyuan.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "Paralegal: Practical Static Analysis for Privacy Bugs"
+    paper_url: "https://www.usenix.org/system/files/osdi25-adam.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "Low End-to-End Latency atop a Speculative Shared Log with Fix-Ante Ordering"
+    paper_url: "https://www.usenix.org/system/files/osdi25-bhat.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "Kamino: Efficient VM Allocation at Scale with Latency-Driven Cache-Aware Scheduling"
+    paper_url: "https://www.usenix.org/system/files/osdi25-domingo.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "Decentralized, Epoch-based F2FS Journaling with Fine-grained Crash Recovery"
+    paper_url: "https://www.usenix.org/system/files/osdi25-cui.pdf"
+    badges: "available,functional"
+
+  - title: "QiMeng-Xpiler: Transcompiling Tensor Programs for Deep Learning Systems with a Neural-Symbolic Approach"
+    paper_url: "https://www.usenix.org/system/files/osdi25-dong.pdf"
+    badges: "available,functional"
+
+  - title: "Stripeless Data Placement for Erasure-Coded In-Memory Storage"
+    paper_url: "https://www.usenix.org/system/files/osdi25-gao.pdf"
+    badges: "available,functional"
+
+  - title: "QOS: Quantum Operating System"
+    paper_url: "https://www.usenix.org/system/files/osdi25-giortamis.pdf"
+    badges: "available"
+
+  - title: "Picsou: Enabling Replicated State Machines to Communicate Efficiently"
+    paper_url: "https://www.usenix.org/system/files/osdi25-frank.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "KPerfIR: Towards a Open and Compiler-centric Ecosystem for GPU Kernel Performance Tooling on Modern AI Workloads"
+    paper_url: "https://www.usenix.org/system/files/osdi25-guan.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "Achieving Low-Latency Graph-Based Vector Search via Aligning Best-First Search Algorithm with SSD"
+    paper_url: "https://www.usenix.org/system/files/osdi25-guo.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "Neutrino: Fine-grained GPU Kernel Profiling via Programmable Probing"
+    paper_url: "https://www.usenix.org/system/files/osdi25-huang-songlin.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "Tigon: A Distributed Database for a CXL Pod"
+    paper_url: "https://www.usenix.org/system/files/osdi25-huang-yibo.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "Training with Confidence: Catching Silent Errors in Deep Learning Training with Automated Proactive Checks"
+    paper_url: "https://www.usenix.org/system/files/osdi25-jiang.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "Bayesian Code Diffusion for Efficient Automatic Deep Learning Program Optimization"
+    paper_url: "https://www.usenix.org/system/files/osdi25-jeong.pdf"
+    badges: "available,functional"
+
+  - title: "PoWER Never Corrupts: Tool-Agnostic Verification of Crash Consistency and Corruption Detection"
+    paper_url: "https://www.usenix.org/system/files/osdi25-leblanc.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "Tintin: A Unified Hardware Performance Profiling Infrastructure to Uncover and Manage Uncertainty"
+    paper_url: "https://www.usenix.org/system/files/osdi25-li.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "Understanding Stragglers in Large Model Training Using What-if Analysis"
+    paper_url: "https://www.usenix.org/system/files/osdi25-lin-jinkun.pdf"
+    badges: "available,functional"
+
+  - title: "Deriving Semantic Checkers from Tests to Detect Silent Failures in Production Distributed Systems"
+    paper_url: "https://www.usenix.org/system/files/osdi25-lou.pdf"
+    badges: "available,functional"
+
+  - title: "Quake: Adaptive Indexing for Vector Search"
+    paper_url: "https://www.usenix.org/system/files/osdi25-mohoney.pdf"
+    badges: "available,functional"
+
+  - title: "MettEagle: Costs and Benefits of Implementing Containers on Microkernels"
+    paper_url: "https://www.usenix.org/system/files/osdi25-miemietz.pdf"
+    badges: "available"
+
+  - title: "Fast and Synchronous Crash Consistency with Metadata Write-Once File System"
+    paper_url: "https://www.usenix.org/system/files/osdi25-pan.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "Building Bridges: Safe Interactions with Foreign Languages through Omniglot"
+    paper_url: "https://www.usenix.org/system/files/osdi25-schuermann.pdf"
+    badges: "available,functional"
+
+  - title: "Enabling Efficient GPU Communication over Multiple NICs with FuseLink"
+    paper_url: "https://www.usenix.org/system/files/osdi25-ren.pdf"
+    badges: "available"
+
+  - title: "XSched: Preemptive Scheduling for Diverse XPUs"
+    paper_url: "https://www.usenix.org/system/files/osdi25-shen-weihang.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "Weave: Efficient and Expressive Oblivious Analytics at Scale"
+    paper_url: "https://www.usenix.org/system/files/osdi25-soleimani.pdf"
+    badges: "available,functional"
+
+  - title: "Scalio: Scaling up DPU-based JBOF Key-value Store with NVMe-oF Target Offload"
+    paper_url: "https://www.usenix.org/system/files/osdi25-sun.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "Quantum Virtual Machines"
+    paper_url: "https://www.usenix.org/system/files/osdi25-tao.pdf"
+    badges: "available,functional"
+
+  - title: "FineMem: Breaking the Allocation Overhead vs. Memory Waste Dilemma in Fine-Grained Disaggregated Memory Management"
+    paper_url: "https://www.usenix.org/system/files/osdi25-wang-xiaoyang.pdf"
+    badges: "available"
+
+  - title: "Mirage: A Multi-Level Superoptimizer for Tensor Programs"
+    paper_url: "https://www.usenix.org/system/files/osdi25-wu-mengdi.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "WLB-LLM: Workload-Balanced 4D Parallelism for Large Language Model Training"
+    paper_url: "https://www.usenix.org/system/files/osdi25-wang-zheng.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "Decouple and Decompose: Scaling Resource Allocation with DeDe"
+    paper_url: "https://www.usenix.org/system/files/osdi25-xu.pdf"
+    badges: "available,functional"
+
+  - title: "BlitzScale: Fast and Live Large Model Autoscaling with O(1) Host Caching"
+    paper_url: "https://www.usenix.org/system/files/osdi25-zhang-dingyan.pdf"
+    badges: "available"
+
+  - title: "KRR: Efficient and Scalable Kernel Record Replay"
+    paper_url: "https://www.usenix.org/system/files/osdi25-zhang-tianren.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "Basilisk: Using Provenance Invariants to Automate Proofs of Undecidable Protocols"
+    paper_url: "https://www.usenix.org/system/files/osdi25-zhang-tony.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "Extending Applications Safely and Efficiently"
+    paper_url: "https://www.usenix.org/system/files/osdi25-zheng-yusheng.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "Compass: Encrypted Semantic Search with High Accuracy"
+    paper_url: "https://www.usenix.org/system/files/osdi25-zhu-jinhao.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "NanoFlow: Towards Optimal Large Language Model Serving Throughput"
+    paper_url: "https://www.usenix.org/system/files/osdi25-zhu-kan.pdf"
+    badges: "available,functional,reproduced"
+---
+
+**Evaluation Results**:
+
+* 38 Artifacts Available
+* 33 Artifacts Functional
+* 22 Results Reproduced
+
+<table>
+  <thead>
+    <tr>
+      <th>Paper title</th>
+      <th>Avail.</th>
+      <th>Funct.</th>
+      <th>Repro.</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for artifact in page.artifacts %}
+    <tr>
+      <td>
+        {% if artifact.paper_url %}
+          <a href="{{artifact.paper_url}}" target="_blank">{{artifact.title}}</a>
+        {% else %}
+          {{ artifact.title }}
+        {% endif %}
+      </td>
+      <td>
+        {% if artifact.badges contains "available" %}
+          <img src="{{ site.baseurl }}/images/{{ page.available_img }}" alt="{{ page.available_name }}" width="50px">
+        {% endif %}
+      </td>
+      <td>
+        {% if artifact.badges contains "functional" %}
+          <img src="{{ site.baseurl }}/images/{{ page.functional_img }}" alt="{{ page.functional_name }}" width="50px">
+        {% endif %}
+      </td>
+      <td>
+        {% if artifact.badges contains "reproduced" %}
+          <img src="{{ site.baseurl }}/images/{{ page.reproduced_img }}" alt="{{ page.reproduced_name }}" width="50px">
+        {% endif %}
+      </td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>


### PR DESCRIPTION
## OSDI 2025 Artifact Evaluation Results

This PR adds the artifact evaluation results page for OSDI 2025, scraped from the [USENIX OSDI 2025 technical sessions](https://www.usenix.org/conference/osdi25/technical-sessions) page.

### Summary
- **38 papers** received artifact evaluation badges (out of 53 accepted papers)
- 38 Artifacts Available
- 33 Artifacts Functional
- 22 Results Reproduced

### Method

Generated using [`generate_results.py`](https://github.com/ReproDB/reprodb-pipeline/blob/main/src/scrapers/generate_results.py) from the [ReproDB pipeline](https://github.com/ReproDB/reprodb-pipeline):

```bash
python -m src.scrapers.generate_results --target sysartifacts --conference osdi --years 2025 --output_dir ./_conferences
```

### Format
Uses YAML front-matter badge format with:
- USENIX badge images (`usenix_available.svg`, `usenix_functional.svg`, `usenix_reproduced.svg`)
- Jekyll/Liquid table template for rendering
- Paper PDF links to usenix.org