### PR TITLE
Add OSDI/ATC 2023 shared AEC member list (106 members)

### DIFF
--- a/_conferences/atc2023/organizers.md
+++ b/_conferences/atc2023/organizers.md
@@ -6,9 +6,114 @@ order: 20
 ## Artifact Evaluation Committee Co-Chairs
 
 [Cesar A. Stuardo](),  The University of Chicago <br>
-[Jianyu Jiang](https://jianyu-m.github.io), Huawei Technologies Co. <br>
-[Nathan Rutherford](https://www.nastr.co.uk), Royal Holloway, University of London <br>
+[Jianyu Jiang](https://jianyu-m.github.io),  Huawei Technologies Co. <br>
+[Nathan Rutherford](https://www.nastr.co.uk),  Royal Holloway, University of London <br>
 
 ## Artifact Evaluation Committee
 
-You? - [Self Nomination Form](https://forms.gle/1xKd8ZrJTsFJcvmGA)
+Abdullah Al Raqibul Islam, University of North Carolina at Charlotte<br>
+Amit Samanta, University of Utah<br>
+Andrei Lebedev, University of Sydney<br>
+Anlan Zhang, University of Minnesota, Twin Cities<br>
+Ao Li, Washington University in St. Louis<br>
+Ariel Szekely, MIT<br>
+Ayush Goel, University of Michigan<br>
+Baber Rehman, The University of Hong Kong<br>
+Benjamin Reidys, UIUC<br>
+Bowen Zhang, The Hong Kong University of Science and Technology<br>
+Boxi Yu, The Chinese University of Hong Kong, Shenzhen<br>
+Chaokun Chang, The Chinese University of Hong Kong<br>
+Chen-Yu Ho, King Abdullah University of Science and Technology<br>
+Chendong Wang, University of Wisconsin Madison<br>
+Chenxia Han, The Chinese University of Hong Kong<br>
+Chris Jensen, University of Cambridge<br>
+Daixuan Li, UIUC<br>
+Daniel Porto, INESC-ID<br>
+David Ke Hong, Meta<br>
+Dongjoo Seo, University of California, Irvine<br>
+Fabrício B. Carvalho, Federal University of Mato Grosso do Sul<br>
+Fadhil I. Kurnia, University of Massachusetts Amherst<br>
+Feiran Qin, ShanghaiTech University<br>
+Gao Wei, Nanyang Technological University<br>
+Gaoxiang Liu, University at Buffalo<br>
+Haofeng Li, The Institute of Computing Technology, Chinese Academy of Sciences<br>
+Haoran Ma, University of California, Los Angeles<br>
+Haoyu Yang, <br>
+Hongyu Cai, University of Massachusetts Amherst<br>
+Hongzheng Chen, Cornell University<br>
+Huangshi Tian, University of Toronto<br>
+Ibrahim Umit Akgun, Stony Brook University<br>
+Imranur Rahman, North Carolina State University<br>
+Jessy Ayala, University of California, Irvine<br>
+Jiamin Li, City University of Hong Kong<br>
+Jianan Yao, Columbia University<br>
+Jiangtao Yu, The University of Hong Kong<br>
+Jiaqi Yao, Zhengzhou University<br>
+Jin Zhang, EPFL<br>
+Jing Liu, University of California, Irvine<br>
+Jinghan Sun, UIUC<br>
+Jingyao Zhang, University of California, Riverside<br>
+Jingzong Li, City University of Hong Kong<br>
+Jinjun Peng, Tsinghua University<br>
+Joshua Fried, MIT<br>
+Karan Newatia, University of Pennsylvania<br>
+Lei Li, City University of Hong Kong<br>
+Lei Yan, EPFL<br>
+Lingyun Yang, Hong Kong University of Science and Technology<br>
+Martin L. Putra, University of Chicago<br>
+Meng Zhang, Nanyang Technological University<br>
+Michael Giardino, Huawei<br>
+Mingyu Li, Shanghai Jiao Tong University<br>
+Minhui Xie, Tsinghua University<br>
+Qiangyu Pei, Huazhong University of Science and Technology<br>
+QiaoLing Chen, National University of Singapore<br>
+Qizheng Zhang, Stanford University<br>
+Rui Pan, Princeton University<br>
+Runbin Shi, ETH Zurich<br>
+Satish Kumar, Apple<br>
+Scofield Zhengqing Liu, Imperial College London<br>
+Sheng Lyu, The University of Hong Kong<br>
+Shi Liu, University of California, Los Angeles<br>
+Siyuan Chai, UIUC<br>
+Soumya Smruti Mishra, Amazon<br>
+Sowmya Dharanipragada, Cornell University<br>
+Stratos Psomadakis, National Technical University of Athens<br>
+Sudheesh Singanamalla, University of Washington<br>
+Suyash Gupta, University of California, Berkeley<br>
+Tharindu B. Hewage, University of Melbourne<br>
+Tianle Zhong, University of Virginia<br>
+Tianrui Wei, University of California, Berkeley<br>
+Vaibhav Bhosale, Georgia Institute of Technology<br>
+Vishal Gupta, EPFL<br>
+Vojtech Aschenbrenner, EPFL<br>
+Wei Chen, The Hong Kong University of Science and Technology<br>
+Weihao Cui, Shanghai Jiao Tong University<br>
+Weilin Zhao, Tsinghua University<br>
+Weiying Hou, The University of Hong Kong<br>
+Wentao Huang, National University of Singapore<br>
+Xian Wang, The University of Hong Kong<br>
+Xianzhong Ding, University of California, Merced<br>
+Xiaoxiang Shi, Shanghai Jiao Tong University<br>
+Xinrui Li, Shanghai Jiao Tong University<br>
+Xuhao Luo, UIUC<br>
+Xupeng Miao, Carnegie Mellon University<br>
+Yi Zhou, Carnegie Mellon University<br>
+Yichao Fu, The University of Hong Kong<br>
+Yifan Qiao, University of California, Los Angeles<br>
+Yifan Yang, University of California, Santa Barbara<br>
+Yifei Liu, Stony Brook University<br>
+Yile Gu, University of Michigan<br>
+Yilei Liang, University of Cambridge<br>
+Yinmin Zhong, Peking University<br>
+Yixin Song, Shanghai Jiaotong University<br>
+Yizhuo Zhai, University of California, Riverside<br>
+Yongfeng Wang, Sun Yat-sen University<br>
+Yu Liang, City University of Hong Kong<br>
+Yunfeng Li, University of California, Santa Barbara<br>
+Yunhong Ji, Renmin University of China<br>
+Yuqi Xue, UIUC<br>
+Zewen Jin, University of Science and Technology of China<br>
+Zhipeng Zhao, Microsoft<br>
+Zhuo Jiang, Bytedance<br>
+Zihao Ye, University of Washington<br>
+Zu-Ming Jiang, ETH Zurich<br>

--- a/_conferences/osdi2023/organizers.md
+++ b/_conferences/osdi2023/organizers.md
@@ -6,9 +6,114 @@ order: 20
 ## Artifact Evaluation Committee Co-Chairs
 
 [Cesar A. Stuardo](),  The University of Chicago <br>
-[Jianyu Jiang](https://jianyu-m.github.io), Huawei Technologies Co. <br>
-[Nathan Rutherford](https://www.nastr.co.uk), Royal Holloway, University of London <br>
+[Jianyu Jiang](https://jianyu-m.github.io),  Huawei Technologies Co. <br>
+[Nathan Rutherford](https://www.nastr.co.uk),  Royal Holloway, University of London <br>
 
 ## Artifact Evaluation Committee
 
-You? - [Self Nomination Form](https://forms.gle/1xKd8ZrJTsFJcvmGA)
+Abdullah Al Raqibul Islam, University of North Carolina at Charlotte<br>
+Amit Samanta, University of Utah<br>
+Andrei Lebedev, University of Sydney<br>
+Anlan Zhang, University of Minnesota, Twin Cities<br>
+Ao Li, Washington University in St. Louis<br>
+Ariel Szekely, MIT<br>
+Ayush Goel, University of Michigan<br>
+Baber Rehman, The University of Hong Kong<br>
+Benjamin Reidys, UIUC<br>
+Bowen Zhang, The Hong Kong University of Science and Technology<br>
+Boxi Yu, The Chinese University of Hong Kong, Shenzhen<br>
+Chaokun Chang, The Chinese University of Hong Kong<br>
+Chen-Yu Ho, King Abdullah University of Science and Technology<br>
+Chendong Wang, University of Wisconsin Madison<br>
+Chenxia Han, The Chinese University of Hong Kong<br>
+Chris Jensen, University of Cambridge<br>
+Daixuan Li, UIUC<br>
+Daniel Porto, INESC-ID<br>
+David Ke Hong, Meta<br>
+Dongjoo Seo, University of California, Irvine<br>
+Fabrício B. Carvalho, Federal University of Mato Grosso do Sul<br>
+Fadhil I. Kurnia, University of Massachusetts Amherst<br>
+Feiran Qin, ShanghaiTech University<br>
+Gao Wei, Nanyang Technological University<br>
+Gaoxiang Liu, University at Buffalo<br>
+Haofeng Li, The Institute of Computing Technology, Chinese Academy of Sciences<br>
+Haoran Ma, University of California, Los Angeles<br>
+Haoyu Yang, <br>
+Hongyu Cai, University of Massachusetts Amherst<br>
+Hongzheng Chen, Cornell University<br>
+Huangshi Tian, University of Toronto<br>
+Ibrahim Umit Akgun, Stony Brook University<br>
+Imranur Rahman, North Carolina State University<br>
+Jessy Ayala, University of California, Irvine<br>
+Jiamin Li, City University of Hong Kong<br>
+Jianan Yao, Columbia University<br>
+Jiangtao Yu, The University of Hong Kong<br>
+Jiaqi Yao, Zhengzhou University<br>
+Jin Zhang, EPFL<br>
+Jing Liu, University of California, Irvine<br>
+Jinghan Sun, UIUC<br>
+Jingyao Zhang, University of California, Riverside<br>
+Jingzong Li, City University of Hong Kong<br>
+Jinjun Peng, Tsinghua University<br>
+Joshua Fried, MIT<br>
+Karan Newatia, University of Pennsylvania<br>
+Lei Li, City University of Hong Kong<br>
+Lei Yan, EPFL<br>
+Lingyun Yang, Hong Kong University of Science and Technology<br>
+Martin L. Putra, University of Chicago<br>
+Meng Zhang, Nanyang Technological University<br>
+Michael Giardino, Huawei<br>
+Mingyu Li, Shanghai Jiao Tong University<br>
+Minhui Xie, Tsinghua University<br>
+Qiangyu Pei, Huazhong University of Science and Technology<br>
+QiaoLing Chen, National University of Singapore<br>
+Qizheng Zhang, Stanford University<br>
+Rui Pan, Princeton University<br>
+Runbin Shi, ETH Zurich<br>
+Satish Kumar, Apple<br>
+Scofield Zhengqing Liu, Imperial College London<br>
+Sheng Lyu, The University of Hong Kong<br>
+Shi Liu, University of California, Los Angeles<br>
+Siyuan Chai, UIUC<br>
+Soumya Smruti Mishra, Amazon<br>
+Sowmya Dharanipragada, Cornell University<br>
+Stratos Psomadakis, National Technical University of Athens<br>
+Sudheesh Singanamalla, University of Washington<br>
+Suyash Gupta, University of California, Berkeley<br>
+Tharindu B. Hewage, University of Melbourne<br>
+Tianle Zhong, University of Virginia<br>
+Tianrui Wei, University of California, Berkeley<br>
+Vaibhav Bhosale, Georgia Institute of Technology<br>
+Vishal Gupta, EPFL<br>
+Vojtech Aschenbrenner, EPFL<br>
+Wei Chen, The Hong Kong University of Science and Technology<br>
+Weihao Cui, Shanghai Jiao Tong University<br>
+Weilin Zhao, Tsinghua University<br>
+Weiying Hou, The University of Hong Kong<br>
+Wentao Huang, National University of Singapore<br>
+Xian Wang, The University of Hong Kong<br>
+Xianzhong Ding, University of California, Merced<br>
+Xiaoxiang Shi, Shanghai Jiao Tong University<br>
+Xinrui Li, Shanghai Jiao Tong University<br>
+Xuhao Luo, UIUC<br>
+Xupeng Miao, Carnegie Mellon University<br>
+Yi Zhou, Carnegie Mellon University<br>
+Yichao Fu, The University of Hong Kong<br>
+Yifan Qiao, University of California, Los Angeles<br>
+Yifan Yang, University of California, Santa Barbara<br>
+Yifei Liu, Stony Brook University<br>
+Yile Gu, University of Michigan<br>
+Yilei Liang, University of Cambridge<br>
+Yinmin Zhong, Peking University<br>
+Yixin Song, Shanghai Jiaotong University<br>
+Yizhuo Zhai, University of California, Riverside<br>
+Yongfeng Wang, Sun Yat-sen University<br>
+Yu Liang, City University of Hong Kong<br>
+Yunfeng Li, University of California, Santa Barbara<br>
+Yunhong Ji, Renmin University of China<br>
+Yuqi Xue, UIUC<br>
+Zewen Jin, University of Science and Technology of China<br>
+Zhipeng Zhao, Microsoft<br>
+Zhuo Jiang, Bytedance<br>
+Zihao Ye, University of Washington<br>
+Zu-Ming Jiang, ETH Zurich<br>


### PR DESCRIPTION
OSDI '23 and ATC '23 shared a joint artifact evaluation committee. The `organizers.md` files previously only listed the 3 co-chairs and a self-nomination form link. This adds the full 106-member AEC list.

**Source:** https://www.usenix.org/conference/osdi23/artifact-evaluation-committee

**Changes:**
- `_conferences/osdi2023/organizers.md` — added 106 AEC members
- `_conferences/atc2023/organizers.md` — identical (shared AEC)

**Chairs (unchanged):**
- Cesar A. Stuardo, The University of Chicago
- Jianyu Jiang, Huawei Technologies Co.
- Nathan Rutherford, Royal Holloway, University of London

<details>
<summary>Verification script</summary>

```python
import requests
from bs4 import BeautifulSoup

resp = requests.get('https://www.usenix.org/conference/osdi23/artifact-evaluation-committee', timeout=30)
soup = BeautifulSoup(resp.text, 'html.parser')
members = soup.select('.field-items .views-row')
print(f'Total entries: {len(members)}')
```
</details>