### PR TITLE
Add ATC 2025 AEC (172 members) and artifact evaluation results (47 artifacts)

### DIFF
--- a/_conferences/atc2025/aec-call.md
+++ b/_conferences/atc2025/aec-call.md
@@ -1,0 +1,5 @@
+---
+title: Call for AEC Members
+order: 20
+redirect_to: https://www.usenix.org/conference/atc25/call-for-artifacts
+---

--- a/_conferences/atc2025/artifacts-call.md
+++ b/_conferences/atc2025/artifacts-call.md
@@ -1,0 +1,5 @@
+---
+title: Call for Artifacts
+order: 10
+redirect_to: https://www.usenix.org/conference/atc25/call-for-artifacts
+---

--- a/_conferences/atc2025/badges.md
+++ b/_conferences/atc2025/badges.md
@@ -1,0 +1,21 @@
+---
+title: Badges
+order: 30
+---
+
+Submitted artifacts could select to be evaluated against the following badges:
+
+<style>
+table th:first-of-type {
+    width: 20%;
+}
+table th:nth-of-type(2) {
+    width: 70%;
+}
+</style>
+
+| USENIX Badges | Description |
+|:-------------:|:------------|
+| ![available badge](../images/usenix_available.svg) | **Artifacts Available:** To earn this badge, the AEC must judge that the artifacts associated with the paper have been made available for retrieval, permanently and publicly. Valid hosting options include institutional repositories and third-party digital repositories (e.g., [Zenodo](https://zenodo.org/), [FigShare](https://figshare.com/), [Dryad](https://datadryad.org/stash/), [Software Heritage](https://archive.softwareheritage.org/), [GitHub](https://github.com/), or [GitLab](https://about.gitlab.com/) — not personal webpages. Other than making the artifacts available, this badge does not mandate any further requirements on functionality, correctness, or documentation. |
+| ![functional badge](../images/usenix_functional.svg) | **Artifacts Functional:** To earn this badge, the AEC must judge that the artifacts conform to the expectations set by the paper in terms of functionality, usability, and relevance. In short, do the artifacts work and are they useful for producing outcomes associated with the paper? The AEC will consider three aspects of the artifacts in particular. <br>**Documentation**: are the artifacts sufficiently documented to enable them to be exercised by readers of the paper? <br>**Completeness**: do the submitted artifacts include all of the key components described in the paper? <br>**Exercisability**: do the submitted artifacts include the scripts and data needed to run the experiments described in the paper, and can the software be successfully executed? |
+| ![reproduced badge](../images/usenix_reproduced.svg) | **Results Reproduced:** To earn this badge, the AEC must judge that they can use the submitted artifacts to obtain the main results presented in the paper. In short, is it possible for the AEC to independently repeat the experiments and obtain results that support the claims made by the paper? The goal of this effort is not to reproduce the results exactly, but instead to generate results independently within an allowed tolerance such that the main claims of the paper are validated. |

--- a/_conferences/atc2025/index.md
+++ b/_conferences/atc2025/index.md
@@ -1,0 +1,13 @@
+---
+title: Artifact Evaluation
+order: 0
+---
+
+A scientific paper consists of a constellation of artifacts that extend beyond
+the document itself: software, hardware, evaluation data and documentation, raw
+survey results, mechanized proofs, models, test suites, benchmarks, and so on.
+In some cases, the quality of these artifacts is as important as that of the
+document itself. Last year, [64% of accepted USENIX ATC papers](https://sysartifacts.github.io/atc2024/results)
+participated in the artifact evaluation process.
+Based on last year's success, USENIX ATC '25 continued to run an optional
+artifact evaluation process combined with OSDI '25.

--- a/_conferences/atc2025/organizers.md
+++ b/_conferences/atc2025/organizers.md
@@ -1,0 +1,184 @@
+---
+title: Organizers
+order: 20
+---
+
+## Artifact Evaluation Committee Co-Chairs
+
+Vijay Chidambaram, The University of Texas at Austin <br>
+Alain Tchana, Grenoble INP <br>
+
+## Artifact Evaluation Committee
+
+Ghazal Abdollahi, University of Utah<br>
+Ghadeer Almusaddar, Binghamton University<br>
+Ayush Bansal, University of Illinois Urbana–Champaign<br>
+Binong Kiri Bey, Indian Institute of Technology<br>
+Archit Bhatnagar, University of Michigan<br>
+Rahul Bothra, University of Illinois Urbana–Champaign<br>
+Cláudia Brito, INESC TEC and University of Minho<br>
+Quinn Burke, University of Wisconsin–Madison<br>
+Cathy Cai, University of Illinois Urbana–Champaign<br>
+Tingjia Cao, University of Wisconsin–Madison<br>
+Sarthak Chakraborty, University of Illinois Urbana–Champaign<br>
+Hongzheng Chen, Cornell University<br>
+Qixuan Chen, Boston University<br>
+Xiang Chen, Hong Kong University of Science and Technology<br>
+Yi Chen, University of Michigan<br>
+Feng Cheng, Duke University<br>
+Georgia Christofidi, IMDEA Software Institute<br>
+Jackson Clark, University of Illinois Urbana–Champaign<br>
+Chuanqi Cong, Beihang University<br>
+Guangyang Deng, Xiamen University<br>
+Jiaqi Deng, Georgia Institute of Technology<br>
+Sriram Devata, University of Illinois Urbana–Champaign<br>
+Huibing Dong, University of Minnesota<br>
+Juechu Dong, University of Michigan<br>
+Chunfeng Du, Zhengzhou University<br>
+Enguang Fan, University of Illinois Urbana–Champaign<br>
+Yuan Feng, University of California, Merced<br>
+Shen Fu, University of Science and Technology of China<br>
+Kaihui Gao, Zhongguancun Laboratory<br>
+Xiangyu Gao, University of Washington<br>
+Raja Gond, Microsoft Research<br>
+Jinnan Guo, Imperial College London<br>
+Ke Han, Purdue University<br>
+Wanning He, University of Michigan<br>
+Kiran Hombal, University of Illinois Urbana–Champaign<br>
+Lana Honcharuk, Crusoe Cloud<br>
+Tony Hong, University of Illinois Urbana–Champaign<br>
+Guanzhou Hu, University of Wisconsin–Madison<br>
+Hao Hu, Harare Institute of Technology<br>
+Tiancheng Hu, Peking University<br>
+Hao Huang, Harbin Institute of Technology<br>
+Lei Huang, Boston University<br>
+Ryan Huang, University of Michigan<br>
+Songlin Huang, The University of Hong Kong<br>
+Yibo Huang, University of Michigan<br>
+Malvika Jadhav, University of Florida<br>
+Shashwat Jaiswal, University of Illinois Urbana–Champaign<br>
+Yuchen Ji, ShanghaiTech University<br>
+Haitian Jiang, New York University<br>
+Teng "Sebastian" Jiang, Columbia University<br>
+Zhihan Jiang, Chinese University of Hong Kong<br>
+Zewen Jin, University of Science and Technology of China<br>
+Sagar Bharadwaj Kalasibail Seetharam, Carnegie Mellon University<br>
+Rishika Varma Kalidindi, University of Michigan<br>
+Saisha Kamat, University of North Carolina at Charlotte<br>
+Ashish Kashinath, University of Illinois Urbana–Champaign<br>
+Zhaokang Ke, University of Minnesota<br>
+Jungwoo Kim, Stanford University<br>
+Fadhil Kurnia, University of Massachusetts Amherst<br>
+Borui Li, Southeast University<br>
+Hanchen Li, Stealth Startup and University of California, Berkeley<br>
+Jiansong Li, Li Auto Inc<br>
+Junzhe Li, The University of Hong Kong<br>
+Shengkai Li, University of Chinese Academy of Sciences<br>
+Sijia Li, Virginia Tech<br>
+Tuo Li, Tsinghua University<br>
+Yueying Li, Cornell University<br>
+Yuke Li, University of California, Merced<br>
+Zeyu Li, Hong Kong University of Science and Technology<br>
+Zhifei Li, University of California, Berkeley<br>
+Junxuan Liao, University of Wisconsin–Madison<br>
+Georgios Liargkovas, Columbia University<br>
+Changyuan Lin, University of British Columbia<br>
+Jing Liu, Max Planck Institute for Security and Privacy<br>
+Peizhe Liu, University of Illinois Urbana–Champaign<br>
+Yiqi Liu, University of Illinois Urbana–Champaign<br>
+Jiaheng Lu, University of Michigan<br>
+Shouxi Luo, Southwest Jiaotong University<br>
+Yilong Luo, Peking University<br>
+Jeff J. Ma, University of Michigan<br>
+Shivani Mehendarge, Amazon<br>
+Deepanjali Mishra, Carnegie Mellon University<br>
+Farzad Mohammadi, Imperial College London<br>
+Grigoris Ntousakis, Brown University<br>
+João Oliveira, INESC-ID and Instituto Superior Técnico, Universidade de Lisboa<br>
+Nikolaos Pagonas, Columbia University<br>
+Jiaqi Pan, University of Illinois Urbana–Champaign and Tsinghua University<br>
+Lichen Pan, Peking University<br>
+Melissa Z. Pan, University of California, Berkeley<br>
+Yanqi Pan, Harbin Institute of Technology<br>
+Zaifeng Pan, University of California, San Diego<br>
+Santosh Pandey, Rutgers University<br>
+Konstantinos Papaioannou, IMDEA Software Institute<br>
+Michael Paper, Stanford University<br>
+Magdalena Pasternak, University of Florida<br>
+Sibendu Paul, Amazon Prime Video<br>
+Pedro Henrique Penna, Microsoft Research<br>
+Stratos Psomadakis, National Technical University of Athens<br>
+Rohan Puri, Samsung Semiconductor<br>
+Shangshu Qian, Purdue University<br>
+Feiran (Alex) Qin, North Carolina State University<br>
+Suyan Qu, University of Wisconsin–Madison<br>
+Vishal Rao, Georgia Institute of Technology<br>
+Siddhant Ray, University of Chicago<br>
+Jonah Rosenblum, University of Michigan<br>
+Giannis Roumpos, IMDEA Software Institute<br>
+Amit Samanta, University of Utah<br>
+Srinjoy Sarkar, Indian Institute of Technology<br>
+Aditya Shah, Google<br>
+Shail Shah, Microsoft<br>
+Shazibul Islam Shamim, Kennesaw State University<br>
+Tanvi Sharma, Purdue University<br>
+Xiaoxiang Shi, Shanghai Jiao Tong University<br>
+Sachin Kumar Singh, University of Utah<br>
+Jiansen Song, Chinese Academy of Sciences<br>
+Yuhang Song, Boston University<br>
+Zihe Song, The University of Texas at Dallas<br>
+Cesar A. Stuardo, ByteDance<br>
+Yiming Su, University of Illinois Urbana–Champaign<br>
+Qingxiao Sun, China University of Petroleum<br>
+Tong Sun, Zhejiang University<br>
+Xin Tan, Chinese University of Hong Kong<br>
+Syed Salauddin Mohammad Tariq, University of Michigan<br>
+Sahil Tyagi, Oak Ridge National Laboratory<br>
+Diogo Vaz, INESC-ID and Instituto Superior Técnico, Universidade de Lisboa<br>
+Alan Wang, Northeastern University<br>
+Ruihong Wang, Purdue University<br>
+Wenlong Wang, University of Minnesota<br>
+Xinkai Wang, Shanghai Jiao Tong University<br>
+Yun Wang, Shanghai Jiao Tong University<br>
+Chiyue Wei, Duke University<br>
+Hengfeng Wei, Nanjing University<br>
+Caeden Whitaker, University of Wisconsin–Madison<br>
+Chao Wu, Nanjing University of Science and Technology<br>
+Yanran Wu, Purdue University<br>
+Zeqing Wu, Zhengzhou University<br>
+Ziqiang Wu, Huazhong University of Science and Technology<br>
+Xingyu Xiang, Harvard University<br>
+Shaokang Xie, University of California, Davis<br>
+Yifan Xie, National University of Defense Technology<br>
+Guanglei Xu, Huazhong University of Science and Technology<br>
+Hanchen Xu, Virginia Tech<br>
+Haocheng Xu, University of California, Irvine<br>
+Tianyin Xu, University of Illinois Urbana–Champaign<br>
+Kaiwen Xue, University of Michigan<br>
+Mingxuan Yang, Imperial College London<br>
+Zhijun Yang, Huazhong University of Science and Technology<br>
+Sheng Yao, Hong Kong University of Science and Technology<br>
+Chenhao Ye, University of Wisconsin–Madison<br>
+Jia Yin, Renmin University<br>
+Jinsun Yoo, Georgia Institute of Technology<br>
+Boxi Yu, Chinese University of Hong Kong<br>
+Diman Zad Tootaghaj, Hewlett Packard Labs<br>
+Wahid Uz Zaman, The Pennsylvania State University<br>
+Ioannis Zarkadas, Columbia University<br>
+Junyao Zhang, Duke University<br>
+Siyuan Zhang, Ohio State University<br>
+Songhao Zhang, University of Illinois Urbana–Champaign<br>
+Wenhui Zhang, ByteDance<br>
+Xiangqun Zhang, Syracuse University<br>
+Xiao Zhang, The University of Texas at Austin<br>
+Yuanliang Zhang, National University of Defense Technology<br>
+Naiqian Zheng, Peking University<br>
+Xinying Zheng, University of Illinois Urbana–Champaign<br>
+Yusheng Zheng, University of California, Santa Cruz<br>
+Shawn Zhong, University of Wisconsin–Madison<br>
+Tianle Zhong, University of Virginia<br>
+Yangjie Zhou, National University of Singapore<br>
+Jianian Zhu, Huazhong University of Science and Technology<br>
+Siqi Zhu, Tsinghua University<br>
+Zeying Zhu, University of Maryland<br>
+Xiangyu Zou, Harbin Institute of Technology<br>

--- a/_conferences/atc2025/results.md
+++ b/_conferences/atc2025/results.md
@@ -1,0 +1,243 @@
+---
+title: Results
+order: 50
+available_img: "usenix_available.svg"
+available_name: "Artifacts Available"
+functional_img: "usenix_functional.svg"
+functional_name: "Artifacts Evaluated - Functional"
+reproduced_img: "usenix_reproduced.svg"
+reproduced_name: "Results Reproduced"
+
+artifacts:
+  - title: "ASTERINAS: A Linux ABI-Compatible, Rust-Based Framekernel OS with a Small and Sound TCB"
+    paper_url: "https://www.usenix.org/system/files/atc25-peng-yuke.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "Burst Computing: Quick, Sudden, Massively Parallel Processing on Serverless Resources"
+    paper_url: "https://www.usenix.org/system/files/atc25-barcelona-pons.pdf"
+    badges: "available,functional"
+
+  - title: "Chitu: Avoiding Unnecessary Fallback in Byzantine Consensus"
+    paper_url: "https://www.usenix.org/system/files/atc25-huang-rongji.pdf"
+    badges: "available,functional"
+
+  - title: "CLONE: Customizing LLMs for Efficient Latency-Aware Inference at the Edge"
+    paper_url: "https://www.usenix.org/system/files/atc25-tian.pdf"
+    badges: "available"
+
+  - title: "Colocating ML Inference and Training with Fast GPU Memory Handover"
+    paper_url: "https://www.usenix.org/system/files/atc25-wang-jiali.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "CrossPipe: Towards Optimal Pipeline Schedules for Cross-Datacenter Training"
+    paper_url: "https://www.usenix.org/system/files/atc25-chen-tiancheng.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "DSA-2LM: A CPU-Free Tiered Memory Architecture with Intel DSA"
+    paper_url: "https://www.usenix.org/system/files/atc25-liu-ruili.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "Fast Distributed Transactions for RDMA-based Disaggregated Memory"
+    paper_url: "https://www.usenix.org/system/files/atc25-lu.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "FlexPipe: Maximizing Training Efficiency for Transformer-based Models with Variable-Length Inputs"
+    paper_url: "https://www.usenix.org/system/files/atc25-zhao-hairui.pdf"
+    badges: "available"
+
+  - title: "GeneralSparse: Bridging the Gap in SpMM for Pruned Large Language Model Inference on GPUs"
+    paper_url: "https://www.usenix.org/system/files/atc25-wang-yaoyu.pdf"
+    badges: "available,functional"
+
+  - title: "GMI-DRL: Empowering Multi-GPU DRL with Adaptive-Grained Parallelism"
+    paper_url: "https://www.usenix.org/system/files/atc25-wang-yuke.pdf"
+    badges: "available,functional"
+
+  - title: "GPREEMPT: GPU Preemptive Scheduling Made General and Efficient"
+    paper_url: "https://www.usenix.org/system/files/atc25-fan.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "GREYHOUND: Hunting Fail-Slows in Hybrid-Parallel Training at Scale"
+    paper_url: "https://www.usenix.org/system/files/atc25-wu-tianyuan.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "HotRAP: Hot Record Retention and Promotion for LSM-trees with Tiered Storage"
+    paper_url: "https://www.usenix.org/system/files/atc25-qiu.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "IRHash: Efficient Multi-Language Compiler Caching by IR-Level Hashing"
+    paper_url: "https://www.usenix.org/system/files/atc25-landsberg.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "JENGA: Enhancing LLM Long-Context Fine-tuning with Contextual Token Sparsity"
+    paper_url: "https://www.usenix.org/system/files/atc25-wang-tuowei.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "Katz: Efficient Workflow Serving for Diffusion Models with Many Adapters"
+    paper_url: "https://www.usenix.org/system/files/atc25-li-suyi-katz.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "LEOCraft: Towards Designing Performant LEO Networks"
+    paper_url: "https://www.usenix.org/system/files/atc25-basak.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "LITESHIELD: Secure Containers via Lightweight, Composable Userspace μKernel Services"
+    paper_url: "https://www.usenix.org/system/files/atc25-manakkal.pdf"
+    badges: "functional"
+
+  - title: "Mitigating Resource Usage Dependency in Sorting-based KV Stores on Hybrid Storage Devices via Operation Decoupling"
+    paper_url: "https://www.usenix.org/system/files/atc25-zhang-qingyang.pdf"
+    badges: "available,functional"
+
+  - title: "mTuner: Accelerating Parameter-Efficient Fine-Tuning on Multi-GPU Servers with Elastic Tensor"
+    paper_url: "https://www.usenix.org/system/files/atc25-huang-kezhao.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "On-Demand Container Partitioning for Distributed ML"
+    paper_url: "https://www.usenix.org/system/files/atc25-bartolomeo.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "Para-ksm: Parallelized Memory Deduplication with Data Streaming Accelerator"
+    paper_url: "https://www.usenix.org/system/files/atc25-ji.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "PathWeaver: A High-Throughput Multi-GPU System for Graph-Based Approximate Nearest Neighbor Search"
+    paper_url: "https://www.usenix.org/system/files/atc25-kim.pdf"
+    badges: "available"
+
+  - title: "Poby: SmartNIC-accelerated Image Provisioning for Coldstart in Clouds"
+    paper_url: "https://www.usenix.org/system/files/atc25-chang.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "PPipe: Efficient Video Analytics Serving on Heterogeneous GPU Clusters via Pool-Based Pipeline Parallelism"
+    paper_url: "https://www.usenix.org/system/files/atc25-kong.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "QFactory: Accelerating Quantized Large Language Model Serving with Qtile Graphs"
+    paper_url: "https://www.usenix.org/system/files/atc25-zhang-qihao.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "Resource Multiplexing in Tuning and Serving Large Language Models"
+    paper_url: "https://www.usenix.org/system/files/atc25-he-yongjun.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "Revealing Floating-Point Accumulation Orders in Software/Hardware Implementations"
+    paper_url: "https://www.usenix.org/system/files/atc25-xie.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "Rex: Closing the language-verifier gap with safe and usable kernel extensions"
+    paper_url: "https://www.usenix.org/system/files/atc25-jia.pdf"
+    badges: "available,functional"
+
+  - title: "SAVE: Software-Implemented Fault Tolerance for Model Inference against GPU Memory Bit Flips"
+    paper_url: "https://www.usenix.org/system/files/atc25-zheng.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "Separate but Together: Integrating Remote Attestation into TLS"
+    paper_url: "https://www.usenix.org/system/files/atc25-weinhold.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "ShieldReduce: Fine-Grained Shielded Data Reduction"
+    paper_url: "https://www.usenix.org/system/files/atc25-yang-jingyuan.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "SpaceExit: Enabling Efficient Adaptive Computing in Space with Early Exits"
+    paper_url: "https://www.usenix.org/system/files/atc25-liu-jiacheng.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "SwCC: Software-Programmable and Per-Packet Congestion Control in RDMA Engine"
+    paper_url: "https://www.usenix.org/system/files/atc25-huang-hongjing.pdf"
+    badges: "available,functional"
+
+  - title: "The Koala Benchmarks for the Shell: Characterization and Implications"
+    paper_url: "https://www.usenix.org/system/files/atc25-lamprou.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "Toppings: CPU-Assisted, Rank-Aware Adapter Serving for LLM Inference"
+    paper_url: "https://www.usenix.org/system/files/atc25-li-suyi-toppings.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "Torpor: GPU-Enabled Serverless Computing for Low-Latency, Resource-Efficient Inference"
+    paper_url: "https://www.usenix.org/system/files/atc25-yu.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "Turbocharge ANNS on Real Processing-in-Memory by Enabling Fine-Grained Per-PIM-Core Scheduling"
+    paper_url: "https://www.usenix.org/system/files/atc25-wu-puqing.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "Understanding and Detecting Fail-Slow Hardware Failure Bugs in Cloud Systems"
+    paper_url: "https://www.usenix.org/system/files/atc25-dong.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "Universal Checkpointing: A Flexible and Efficient Distributed Checkpointing System for Large-Scale DNN Training with Reconfigurable Parallelism"
+    paper_url: "https://www.usenix.org/system/files/atc25-lian.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "Unveiling Compiler Faults via Attribute-Guided Compilation Space Exploration"
+    paper_url: "https://www.usenix.org/system/files/atc25-wu-jiangchang.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "Voltrix: Sparse Matrix-Matrix Multiplication on Tensor Cores with Asynchronous and Balanced Kernel Optimization"
+    paper_url: "https://www.usenix.org/system/files/atc25-xia.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "Weaver: Efficient Multi-LLM Serving with Attention Offloading"
+    paper_url: "https://www.usenix.org/system/files/atc25-gao.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "XRT: An Accelerator-Aware Runtime for Accelerated Chip Multiprocessors"
+    paper_url: "https://www.usenix.org/system/files/atc25-patel.pdf"
+    badges: "available,functional,reproduced"
+
+  - title: "μEFI: A Microkernel-Style UEFI with Isolation and Transparency"
+    paper_url: "https://www.usenix.org/system/files/atc25-chen-le.pdf"
+    badges: "available,functional,reproduced"
+
+---
+
+**Submissions**: 46 (46% of accepted papers)
+
+**Evaluation Results**:
+
+* 45 Artifacts Available
+* 43 Artifacts Functional
+* 35 Results Reproduced
+
+<table>
+  <thead>
+    <tr>
+      <th>Paper title</th>
+      <th>Avail.</th>
+      <th>Funct.</th>
+      <th>Repro.</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for artifact in page.artifacts %}
+    <tr>
+      <td>
+        {% if artifact.paper_url %}
+          <a href="{{artifact.paper_url}}" target="_blank">{{artifact.title}}</a>
+        {% else %}
+          {{ artifact.title }}
+        {% endif %}
+      </td>
+      <td>
+        {% if artifact.badges contains "available" %}
+          <img src="{{ site.baseurl }}/images/{{ page.available_img }}" alt="{{ page.available_name }}" width="50px">
+        {% endif %}
+      </td>
+      <td>
+        {% if artifact.badges contains "functional" %}
+          <img src="{{ site.baseurl }}/images/{{ page.functional_img }}" alt="{{ page.functional_name }}" width="50px">
+        {% endif %}
+      </td>
+      <td>
+        {% if artifact.badges contains "reproduced" %}
+          <img src="{{ site.baseurl }}/images/{{ page.reproduced_img }}" alt="{{ page.reproduced_name }}" width="50px">
+        {% endif %}
+      </td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>


### PR DESCRIPTION
Adds the full ATC 2025 conference data including AEC member list, results, and page structure.

**New files:**
- `_conferences/atc2025/organizers.md` — 2 chairs + 172 AEC members
- `_conferences/atc2025/results.md` — 47 evaluated artifacts with badge assignments
- `_conferences/atc2025/index.md`, `badges.md`, `aec-call.md`, `artifacts-call.md` — conference page structure

**Chairs:**
- Vijay Chidambaram, The University of Texas at Austin
- Alain Tchana, Grenoble INP

**Source:** https://www.usenix.org/conference/atc25/artifact-evaluation-committee